### PR TITLE
Add suffix-based aggregate column support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "protich/auto-join-eloquent",
   "description": "Extend Eloquent to support auto-joining relationships and aliasing for SELECT, WHERE, ORDERBY, GROUPBY and HAVING clauses",
   "type": "library",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "MIT",
   "authors": [
     {

--- a/tests/Unit/CoalesceColumnTest.php
+++ b/tests/Unit/CoalesceColumnTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Protich\AutoJoinEloquent\Tests\Unit;
+namespace protich\AutoJoinEloquent\Tests\Unit;
 
-use Protich\AutoJoinEloquent\Tests\AutoJoinTestCase;
-use Protich\AutoJoinEloquent\Tests\Models\User;
+use protich\AutoJoinEloquent\Tests\AutoJoinTestCase;
+use protich\AutoJoinEloquent\Tests\Models\User;
 use Illuminate\Support\Facades\DB;
 
 class CoalesceColumnTest extends AutoJoinTestCase

--- a/tests/Unit/SuffixCountsTest.php
+++ b/tests/Unit/SuffixCountsTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace protich\AutoJoinEloquent\Tests\Unit;
+
+use protich\AutoJoinEloquent\Tests\AutoJoinTestCase;
+use protich\AutoJoinEloquent\Tests\Models\User;
+
+class SuffixCountsTest extends AutoJoinTestCase
+{
+    public function test_select_with_counts_suffix(): void
+    {
+        $query = User::query()
+            ->select([
+                'name',
+                'agent__departments.id__counts as dept_count',
+            ])
+            ->groupBy('agent.id');
+
+        $sql = $this->debugSql($query);
+
+        $this->assertStringContainsStringIgnoringCase('COUNT', $sql);
+        $this->assertStringContainsStringIgnoringCase('as "dept_count"', $sql);
+        $this->assertStringContainsStringIgnoringCase('JOIN', $sql);
+
+        $this->assertNonEmptyResults($query->get()->toArray());
+    }
+
+    public function test_order_by_with_counts_suffix(): void
+    {
+        $query = User::query()
+            ->select([
+                'name',
+                'agent__departments.id__counts as dept_count',
+            ])
+            ->groupBy('agent.id')
+            ->orderBy('agent__departments.id__counts', 'desc');
+
+        $sql = $this->debugSql($query);
+
+        $this->assertStringContainsStringIgnoringCase('COUNT', $sql);
+        $this->assertStringContainsStringIgnoringCase('ORDER BY', $sql);
+
+        $this->assertNonEmptyResults($query->get()->toArray());
+    }
+
+    public function test_having_with_counts_suffix(): void
+    {
+        $query = User::query()
+            ->select([
+                'name',
+                'agent__departments.id__counts as dept_count',
+            ])
+            ->groupBy('agent.id')
+            ->having('agent__departments.id__counts', '>', 0);
+
+        $sql = $this->debugSql($query);
+
+        $this->assertStringContainsStringIgnoringCase('HAVING', $sql);
+        $this->assertStringContainsStringIgnoringCase('COUNT', $sql);
+
+        $this->assertNonEmptyResults($query->get()->toArray());
+    }
+}


### PR DESCRIPTION
This PR builds on the BaseCompiler refactor and introduces support for suffix-based aggregate compilation. It enables view and config definitions to remain declarative while still expressing aggregate logic.

### ✨ Features

Supports suffix-based aggregate expressions:
- `__counts → COUNT(...)`
- `__sum → SUM(...)`
- `__avg → AVG(...)`
- `__min → MIN(...)`
- `__max → MAX(...)`

Works in:
- `SELECT` clauses (with alias support)
- `HAVING` clauses
- `ORDER BY` clauses

Automatically compiles expressions like:
```sql
'agent__departments.id__counts as dept_count'
```
Into SQL like:
```sql
COUNT(D.id) as dept_count
```

### 🧪 Tests
Adds SuffixCountsTest to verify suffix behavior in:

- SELECT output
- HAVING filters
- ORDER BY sorting
- Ensures aliasing, joins, and groupings are preserved correctly

### 🔒 Guardrails
Aggregate suffixes are disabled for `WHERE` and `GROUP BY` clauses, which do not support aggregate functions in standard SQL
