### PR TITLE
Rename aggregate suffix from __counts to __count

### DIFF
--- a/src/Compilers/BaseCompiler.php
+++ b/src/Compilers/BaseCompiler.php
@@ -11,7 +11,7 @@ use Illuminate\Database\Query\Expression;
  * Provides shared logic for compiling SQL expressions across SELECT, WHERE, HAVING, GROUP BY, and ORDER BY clauses.
  * Handles support for:
  * - Relationship-aware column resolution
- * - Suffix-based aggregates (e.g., __counts)
+ * - Suffix-based aggregates (e.g., __count)
  * - COALESCE(...) expressions
  * - Aggregate SQL parsing (e.g., COUNT(...), SUM(...))
  */
@@ -48,7 +48,7 @@ abstract class BaseCompiler
 
             // Structured clause: column or raw SQL
             if (is_array($clause)) {
-                // ['column' => 'user.id__counts']
+                // ['column' => 'user.id__count']
                 if (isset($clause['column'])) {
                     $compiled = $this->compileColumn((string) $clause['column']);
                     $clause['column'] = $compiled instanceof Expression ? $compiled : (string) $compiled;
@@ -71,7 +71,7 @@ abstract class BaseCompiler
      *
      * Supports:
      * - Aggregates (COUNT(...), SUM(...))
-     * - Suffix-based aggregates (e.g., __counts)
+     * - Suffix-based aggregates (e.g., __count)
      * - COALESCE(...)
      * - Basic relationship-aware columns
      *
@@ -150,7 +150,7 @@ abstract class BaseCompiler
     }
 
     /**
-     * Detect and parse aggregate functions, including suffix-based style (e.g., __counts).
+     * Detect and parse aggregate functions, including suffix-based style (e.g., __count).
      *
      * @param string $expression
      * @return array{aggregateFunction: string, innerExpression: string, alias: string|null, outerExpression: string}|false
@@ -169,12 +169,12 @@ abstract class BaseCompiler
             ];
         }
 
-        // Suffix-based shorthand (e.g., user.id__counts)
+        // Suffix-based shorthand (e.g., user.id__count)
         if (!($this instanceof WhereCompiler || $this instanceof GroupByCompiler)
-            && preg_match('/^(.*?)__(counts|sum|avg|min|max)(?:\s+as\s+(\w+))?$/i', $expression, $m)) {
+            && preg_match('/^(.*?)__(count|sum|avg|min|max)(?:\s+as\s+(\w+))?$/i', $expression, $m)) {
 
             $functionMap = [
-                'counts' => 'COUNT',
+                'count' => 'COUNT',
                 'sum'    => 'SUM',
                 'avg'    => 'AVG',
                 'min'    => 'MIN',

--- a/tests/Unit/SuffixCountsTest.php
+++ b/tests/Unit/SuffixCountsTest.php
@@ -12,7 +12,7 @@ class SuffixCountsTest extends AutoJoinTestCase
         $query = User::query()
             ->select([
                 'name',
-                'agent__departments.id__counts as dept_count',
+                'agent__departments.id__count as dept_count',
             ])
             ->groupBy('agent.id');
 
@@ -30,10 +30,10 @@ class SuffixCountsTest extends AutoJoinTestCase
         $query = User::query()
             ->select([
                 'name',
-                'agent__departments.id__counts as dept_count',
+                'agent__departments.id__count as dept_count',
             ])
             ->groupBy('agent.id')
-            ->orderBy('agent__departments.id__counts', 'desc');
+            ->orderBy('agent__departments.id__count', 'desc');
 
         $sql = $this->debugSql($query);
 
@@ -48,10 +48,10 @@ class SuffixCountsTest extends AutoJoinTestCase
         $query = User::query()
             ->select([
                 'name',
-                'agent__departments.id__counts as dept_count',
+                'agent__departments.id__count as dept_count',
             ])
             ->groupBy('agent.id')
-            ->having('agent__departments.id__counts', '>', 0);
+            ->having('agent__departments.id__count', '>', 0);
 
         $sql = $this->debugSql($query);
 


### PR DESCRIPTION
This PR updates the suffix-based aggregate handling system to use the singular form` __count` instead of `__counts`, aligning more closely with standard SQL naming and improving consistency.

### ✅ What’s changed

Replaces `__counts` with `__count` in:
- Suffix detection pattern (parseAggregateExpression)
-  Aggregate function map (count, sum, etc.)

Updated `SuffixCountsTest` to reflect the new convention:
- All test cases now use `__count`
- Ensures `SELECT`, `HAVING`, and `ORDER BY` use `COUNT(...)` correctly

### 🧠 Why

- COUNT is the SQL function name — not COUNTS
- Singular form is consistent with existing suffixes like `__sum`, `__avg`, `__min`, `__max`
- Aligns better with expectations from users familiar with SQL or Laravel’s query builder

### 🛡️ Notes

- This is a breaking change if configs or view columns are currently using `__counts`