### PR TITLE
Add support for chain normalization and explicit control over alias inference

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "protich/auto-join-eloquent",
   "description": "Extend Eloquent to support auto-joining relationships and aliasing for SELECT, WHERE, ORDERBY, GROUPBY and HAVING clauses",
   "type": "library",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "license": "MIT",
   "authors": [
     {

--- a/src/Compilers/BaseCompiler.php
+++ b/src/Compilers/BaseCompiler.php
@@ -228,7 +228,7 @@ abstract class BaseCompiler
     {
         $grammar = $this->builder->getGrammar();
         $parsed = $this->parseColumnParts($info['innerExpression']);
-        $resolved = $this->builder->resolveColumnExpression($parsed['column']);
+        $resolved = $this->builder->resolveColumnExpression($parsed['column'], null, false);
 
         $innerSql = $resolved->getValue($grammar); // @phpstan-ignore-line
 
@@ -304,8 +304,8 @@ abstract class BaseCompiler
 
         $resolved = array_map(function ($field) use ($grammar) {
             $column = $this->parseColumnParts($field)['column'];
-            $expr = $this->builder->resolveColumnExpression($column);
-            
+            $expr = $this->builder->resolveColumnExpression($column, null, false);
+            // @phpstan-ignore-next-line
             return $expr->getValue($grammar);// @phpstan-ignore-line
         }, $info['fields']);
 

--- a/tests/Unit/ColumnNormalizationTest.php
+++ b/tests/Unit/ColumnNormalizationTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace protich\AutoJoinEloquent\Tests\Unit;
+
+use protich\AutoJoinEloquent\Tests\AutoJoinTestCase;
+use protich\AutoJoinEloquent\Tests\Models\User;
+
+class ColumnNormalizationTest extends AutoJoinTestCase
+{
+    public function test_dot_based_column_is_preserved(): void
+    {
+        $query = User::query()
+            ->select(['name as Name', 'agent__departments|inner.name as
+            Department', 'agent__departments__manager__user.name as
+            mgr_name']);
+
+        $sql = $this->debugSql($query);
+
+        $this->assertStringContainsStringIgnoringCase('JOIN', $sql);
+        $this->assertStringContainsStringIgnoringCase('."name"', $sql);
+        $this->assertStringContainsStringIgnoringCase('as "mgr_name"', $sql);
+
+        $this->assertNonEmptyResults($query->get()->toArray());
+    }
+
+    public function test_column_without_dot_infers_primary_key_field(): void
+    {
+        $query = User::query()
+            ->select(['name as Name', 'agent__departments|inner.name as
+            Department', 'agent__departments__manager__user']);
+
+        $sql = $this->debugSql($query);
+
+        $this->assertStringContainsStringIgnoringCase('JOIN', $sql);
+        $this->assertStringContainsStringIgnoringCase('."id"', $sql);
+        $this->assertStringContainsStringIgnoringCase('agent__departments__manager__user', $sql);
+
+        $this->assertNonEmptyResults($query->get()->toArray());
+    }
+
+    public function test_plain_field_expression_is_not_joined(): void
+    {
+        $query = User::query()
+            ->select(['id', 'status']);
+
+        $sql = $this->debugSql($query);
+
+        $this->assertStringNotContainsStringIgnoringCase('JOIN', $sql);
+        $this->assertStringContainsStringIgnoringCase('status', $sql);
+    }
+
+    public function test_invalid_final_relation_becomes_field(): void
+    {
+        $query = User::query()
+            ->select(['agent__nonexistent as maybe_field']);
+
+        $sql = $this->debugSql($query);
+
+        $this->assertStringContainsStringIgnoringCase('agent', $sql);
+        $this->assertStringNotContainsStringIgnoringCase('nonexistent.', $sql);
+        $this->assertStringContainsStringIgnoringCase('as "maybe_field"', $sql);
+    }
+
+    public function test_suffix_based_aggregate_counts_related_departments(): void
+    {
+        $query = User::query()
+            ->select(['name', 'agent__departments__count as dept_count'])
+            ->groupBy('agent.id');
+
+        $sql = $this->debugSql($query);
+
+        $this->assertStringContainsStringIgnoringCase('COUNT', $sql);
+        $this->assertStringContainsStringIgnoringCase('as "dept_count"', $sql);
+        $this->assertStringContainsStringIgnoringCase('departments', $sql);
+
+        $this->assertNonEmptyResults($query->get()->toArray());
+    }
+
+    /**
+     * Ensure suffix-based aggregate can be used in a HAVING clause.
+     */
+    public function test_suffix_aggregate_in_having_clause(): void
+    {
+        $query = User::query()
+            ->select(['name', 'agent__departments__count as dept_count'])
+            ->groupBy('agent.id')
+            ->having('agent__departments__count', '>', 0)
+            ->orderBy('name', 'asc');
+
+        $sql = $this->debugSql($query);
+
+        $this->assertStringContainsStringIgnoringCase('HAVING', $sql);
+        $this->assertStringContainsStringIgnoringCase('COUNT', $sql);
+
+        $this->assertNonEmptyResults($query->get()->toArray());
+    }
+
+    /**
+     * Ensure suffix-based aggregate can be used in ORDER BY.
+     */
+    public function test_suffix_aggregate_in_order_by_clause(): void
+    {
+        $query = User::query()
+            ->select(['name', 'agent__departments__count as dept_count'])
+            ->groupBy('agent.id')
+            ->orderBy('agent__departments__count', 'desc');
+
+        $sql = $this->debugSql($query);
+
+        $this->assertStringContainsStringIgnoringCase('ORDER BY', $sql);
+        $this->assertStringContainsStringIgnoringCase('COUNT', $sql);
+
+        $this->assertNonEmptyResults($query->get()->toArray());
+    }
+
+    /**
+     * Ensure explicit alias suppresses auto-generated alias.
+     */
+    public function test_explicit_alias_overrides_auto_aliasing(): void
+    {
+        $query = User::query()
+            ->select(['agent__departments__manager__user as manager_id']);
+
+        $sql = $this->debugSql($query);
+
+        $this->assertStringContainsStringIgnoringCase('JOIN', $sql);
+        $this->assertStringContainsStringIgnoringCase('as "manager_id"', $sql);
+        $this->assertStringNotContainsStringIgnoringCase('agent__departments__manager__user', $sql);
+    }
+}


### PR DESCRIPTION
This PR introduces a robust normalization layer for column parsing, along with fine-grained control over alias inference. It addresses resolution of ambiguous expressions, improves auto-generated alias behavior, and locks in expected behavior via tests.

### What’s included

**1. Column Chain Normalization**
 - Introduced normalizeChainParts() to handle field inference from relationship-only expressions (e.g. `department__manager__user`)
 - Ensures correct field is selected (id / primary key from related model) when no field is explicitly specified (e.g `agent_departments__count`)
 - If final chain segment is not a relationship, it is treated as a field and excluded from join chain

**2. Alias Inference via $allowAutoAliasing**
- `resolveColumnExpression()` now accepts a third parameter: `$allowAutoAliasing`
- When enabled, inferred fields may result in fallback aliases based on joined relation chain (e.g. `agent_departments__manager__user`)
- Compiler methods like `compileAggregateExpression()` and `compileCoalesceExpression()` disable auto-aliasing to prevent unintended alias propagation

**3. ColumnNormalizationTest**

Adds a test suite to validate:
- Dot-based and dotless expressions
- Suffix-based aggregates (e.g., `__count`)
- Auto-aliasing behavior
- `HAVING` and `ORDER BY` compatibility
- Explicit alias overrides
- Handling of invalid chain segments

Happy auto-joining! 