### PR TITLE
Add Support for Nested WHERE Clauses

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "protich/auto-join-eloquent",
   "description": "Extend Eloquent to support auto-joining relationships and aliasing for SELECT, WHERE, ORDERBY, GROUPBY and HAVING clauses",
   "type": "library",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "MIT",
   "authors": [
     {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "protich/auto-join-eloquent",
   "description": "Extend Eloquent to support auto-joining relationships and aliasing for SELECT, WHERE, ORDERBY, GROUPBY and HAVING clauses",
   "type": "library",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "license": "MIT",
   "authors": [
     {

--- a/src/Compilers/WhereCompiler.php
+++ b/src/Compilers/WhereCompiler.php
@@ -2,6 +2,7 @@
 
 namespace protich\AutoJoinEloquent\Compilers;
 
+use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Query\Expression;
 use Exception;
 
@@ -13,17 +14,18 @@ use Exception;
  */
 class WhereCompiler extends BaseCompiler
 {
+
     /**
      * Compile a WHERE clause column expression.
      *
-     * WHERE clauses cannot include aggregate functions.
-     * This override throws if an aggregate is detected, but otherwise delegates
-     * to the parent compiler with aliasing disabled (as WHERE does not accept aliases).
+     * WHERE clauses do not support SQL aliases or aggregate functions.
+     * This method throws if an aggregate is detected, and otherwise delegates
+     * to the base compiler with aliasing explicitly disabled.
      *
      * @param string $column The raw column expression.
-     * @param bool $allowAlias Required by signature, ignored here.
-     * @return Expression The compiled expression for the WHERE clause.
-     * @throws Exception If an aggregate expression is used in WHERE.
+     * @param bool $allowAlias Required by interface; always ignored (false).
+     * @return Expression The compiled expression.
+     * @throws Exception If an aggregate expression is detected in WHERE clause.
      */
     public function compileColumn(string $column, bool $allowAlias = false): Expression
     {
@@ -33,5 +35,43 @@ class WhereCompiler extends BaseCompiler
 
         // Aliasing not allowed — pass false explicitly
         return parent::compileColumn($column, false);
+    }
+
+    /**
+     * Compile all WHERE clause entries, including nested expressions.
+     *
+     * Recursively compiles nested where groups (type = "Nested") using a fresh WhereCompiler instance.
+     *
+     * @param array<int, mixed> $wheres
+     * @return array<int, mixed>
+     */
+    public function compileClause(array $wheres): array
+    {
+        return collect($wheres)->map(function (mixed $where) {
+            if (is_array($where)) {
+                if (isset($where['type'])
+                    && $where['type'] === 'Nested'
+                    && $where['query'] instanceof Builder) {
+                    // Recursively compile the nested where builder
+                    $nestedCompiler = new self($this->builder);
+                    $compiledNested = $nestedCompiler->compileClause($where['query']->wheres ?? []);
+                    $where['query']->wheres = $compiledNested;
+                    return $where;
+                }
+
+                // Standard column or raw SQL expression
+                if (isset($where['column'])) {
+                    $compiled = $this->compileColumn((string) $where['column']);
+                    $where['column'] = $compiled instanceof Expression ? $compiled : (string) $compiled;
+                }
+
+                if (isset($where['sql'])
+                    && strcasecmp((string) ($where['type'] ?? ''), 'Raw') === 0) {
+                    $where['sql'] = $this->compileRawSql((string) $where['sql']);
+                }
+            }
+
+            return $where;
+        })->all();
     }
 }

--- a/tests/Setup/schemas/default/migrations/2003_01_01_0002_create_agents_table.php
+++ b/tests/Setup/schemas/default/migrations/2003_01_01_0002_create_agents_table.php
@@ -14,6 +14,7 @@ class CreateAgentsTable extends Migration
     {
         Capsule::schema()->create('agents', function (Blueprint $table) {
             $table->increments('id');
+            $table->unsignedInteger('flags')->default(0);
             // Foreign key referencing users.id.
             $table->unsignedInteger('user_id')->nullable();
             // Position field for the agent.

--- a/tests/Unit/BitwiseClauseTest.php
+++ b/tests/Unit/BitwiseClauseTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace protich\AutoJoinEloquent\Tests\Unit;
+
+use protich\AutoJoinEloquent\Tests\AutoJoinTestCase;
+use protich\AutoJoinEloquent\Tests\Models\User;
+
+class BitwiseClauseTest extends AutoJoinTestCase
+{
+    public function test_bitwise_expression_with_relationship_column(): void
+    {
+        $query = User::query()
+            ->select(['name'])
+            ->whereRaw('agent.flags & ? = 0', [1]);
+
+        $sql = $this->debugSql($query);
+
+        $this->assertStringContainsString('agent', $sql);
+        $this->assertStringContainsString('&', $sql);
+        $this->assertStringContainsString('= 0', $sql);
+    }
+}

--- a/tests/Unit/NestedWhereTest.php
+++ b/tests/Unit/NestedWhereTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace protich\AutoJoinEloquent\Tests\Unit;
+
+use protich\AutoJoinEloquent\Tests\AutoJoinTestCase;
+use protich\AutoJoinEloquent\Tests\Models\User;
+
+class NestedWhereTest extends AutoJoinTestCase
+{
+    public function test_nested_where_with_structured_and_raw_conditions(): void
+    {
+        $query = User::query()
+            ->select(['name'])
+            ->where(function ($q) {
+                $q->where('agent__departments__manager__user.id', '=', 1)
+                  ->orWhere('agent__departments.name', 'like', 'S%');
+            })
+            ->where('agent__departments__manager__user.id', '>', 0);
+
+        $sql = $this->debugSql($query);
+
+        $this->assertStringContainsStringIgnoringCase('JOIN', $sql);
+        $this->assertStringContainsStringIgnoringCase('WHERE', $sql);
+        $this->assertStringContainsStringIgnoringCase('agent_department', $sql);
+        $this->assertStringContainsStringIgnoringCase('manager', $sql);
+        $this->assertStringContainsStringIgnoringCase('user', $sql);
+        $this->assertStringContainsStringIgnoringCase('id', $sql);
+
+        $this->assertNonEmptyResults($query->get()->toArray());
+    }
+}


### PR DESCRIPTION
This PR adds support for compiling nested WHERE clause groups (`type = "Nested"`) via recursive processing in the `WhereCompiler`.

### Key Changes

- Nested Builder instances are now recursively compiled, allowing relationship paths inside nested conditions to be resolved correctly.
- All nested clauses including column, raw, and compound logic are processed uniformly through the same compiler logic.
- Ensures that bitwise and COALESCE expressions inside nested blocks are handled consistently.

#### Additional Improvements

- Introduced `shouldResolveColumn()` to generalize detection of resolvable column paths, enabling broader use cases beyond relationship chains.
- `isRelationshipReference()` now delegates to `shouldResolveColumn()` to support resolution of simple fields like flags without requiring dot/underscore notation.

This builds on bitwise expression support PR and is released as part of **v0.9.0**.