### PR TITLE
chore: bump version to v0.9.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "protich/auto-join-eloquent",
   "description": "Extend Eloquent to support auto-joining relationships and aliasing for SELECT, WHERE, ORDERBY, GROUPBY and HAVING clauses",
   "type": "library",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "license": "MIT",
   "authors": [
     {


### PR DESCRIPTION
Includes PHPStan-related fixes and type safety improvements:
- Added missing iterable types in compiler signatures
- Ignored specific false positives for Laravel internals
- Improved docblocks for static analysis compatibility