### PR TITLE
Add EXISTS strategy for multi-path distinct counts

### DIFF
--- a/src/AutoJoinQueryBuilder.php
+++ b/src/AutoJoinQueryBuilder.php
@@ -415,6 +415,31 @@ class AutoJoinQueryBuilder extends EloquentBuilder
     }
 
     /**
+     * Parse and normalize a column relationship chain for compiler use.
+     *
+     * This exposes the builder's internal chain parsing so compiler
+     * strategies such as EXISTS-based path counting can reuse the same
+     * relationship and field normalization logic used by normal column
+     * resolution.
+     *
+     * @param  string      $column
+     * @param  string|null $baseTable
+     * @param  bool        $allowAutoAliasing
+     * @return array{
+     *     chain: array<int, array{relation: string, join: string}>,
+     *     field: string|null,
+     *     alias: string|null
+     * }
+     */
+    public function describeColumnChain(
+        string $column,
+        ?string $baseTable = null,
+        bool $allowAutoAliasing = true
+    ): array {
+        return $this->parseColumnChain($column, $baseTable, $allowAutoAliasing);
+    }
+
+    /**
      * Parse a column expression into its components: relationship chain, field, and alias.
      *
      * Handles dot-based and relationship-based expressions such as:
@@ -1044,9 +1069,13 @@ class AutoJoinQueryBuilder extends EloquentBuilder
         ?string $queryCompilerClass = null
     ): void {
         $grammar = $this->getGrammar();
-        $from    = $query->from;
+        $from = $query->from;
 
-        $alias = $this->parseAlias($from);
+        if ($from instanceof Expression) {
+            $from = $from->getValue($grammar); // @phpstan-ignore-line
+        }
+
+        $alias = $this->parseAlias((string) $from);
 
         if ($alias !== null) {
             $this->setBaseAlias($alias);

--- a/src/Compilers/BaseCompiler.php
+++ b/src/Compilers/BaseCompiler.php
@@ -186,16 +186,38 @@ abstract class BaseCompiler
         }
 
         // Normalize dot notation (user.agent.id → user__agent.id)
-        $parts = explode('.', $column);
-        if (count($parts) > 1) {
-            $field = array_pop($parts);
-            $column = implode('__', $parts) . '.' . $field;
-        }
+        $column = $this->normalizeColumn($column);
 
         return [
             'column' => $column,
             'alias'  => $alias,
         ];
+    }
+
+    /**
+     * Normalize a column expression to relationship-chain form.
+     *
+     * Converts dot notation into auto-join format:
+     * - user.agent.id → user__agent.id
+     *
+     * Does not parse or extract alias.
+     *
+     * @param  string $column
+     * @return string
+     */
+    protected function normalizeColumn(string $column): string
+    {
+        $column = trim($column);
+
+        $parts = explode('.', $column);
+
+        if (count($parts) > 1) {
+            $field = array_pop($parts);
+
+            return implode('__', $parts) . '.' . $field;
+        }
+
+        return $column;
     }
 
     /**
@@ -514,15 +536,102 @@ abstract class BaseCompiler
     }
 
     /**
-     * Compile a multi-path count descriptor using correlated subqueries.
+     * Compile a multi-path count descriptor.
      *
-     * Paths are compiled into correlated select subqueries and combined
-     * using UNION when distinct=true.
+     * Distinct multi-path counts that terminate on the same target are
+     * compiled using an EXISTS-based strategy. All other multi-path counts
+     * fall back to the UNION-based strategy.
      *
      * @param  Descriptor $descriptor
      * @return Expression
      */
     protected function compileMultiPathCountDescriptor(Descriptor $descriptor): Expression
+    {
+        if (! $descriptor->distinct()) {
+            throw new \RuntimeException(
+                'Multi-path count descriptors currently require [distinct => true].'
+            );
+        }
+
+        $paths = $descriptor->paths();
+
+        if ($this->canCompileExistsCountDescriptor($paths)) {
+            return $this->compileExistsCountDescriptor($descriptor);
+        }
+
+        return $this->compileUnionCountDescriptor($descriptor);
+    }
+
+    /**
+     * Compile a multi-path count descriptor using a target-anchored
+     * EXISTS strategy.
+     *
+     * This strategy is used when all paths terminate on the same target
+     * relation and column. The target table becomes the driving table,
+     * and each path is compiled into an EXISTS predicate correlated to:
+     *
+     * - the outer record
+     * - the current target row
+     *
+     * Example shape:
+     *
+     *   select count(*)
+     *   from target t
+     *   where exists(path1 for outer row -> t)
+     *      or exists(path2 for outer row -> t)
+     *
+     * This avoids UNION-based correlated derived tables and is compatible
+     * with MySQL correlation rules.
+     *
+     * @param  Descriptor $descriptor
+     * @return Expression
+     */
+    protected function compileExistsCountDescriptor(Descriptor $descriptor): Expression
+    {
+        if (! $descriptor->distinct()) {
+            throw new \RuntimeException(
+                'EXISTS-based count descriptors currently require [distinct => true].'
+            );
+        }
+
+        $paths    = $descriptor->paths();
+        $grammar  = $this->builder->getGrammar();
+        $compiler = new SubqueryCompiler($this->builder);
+
+        $sql = $compiler->compileExistsCountSubquerySql($paths);
+
+        $alias = $descriptor->alias();
+
+        if ($alias === null && $descriptor->shouldAutoAlias()) {
+            $alias = $this->makeAggregateAlias(
+                'COUNT',
+                implode('_', $paths)
+            );
+        }
+
+        if ($alias !== null) {
+            $sql .= ' as ' . $grammar->wrap($alias);
+        }
+
+        return new SubQueryExpression($sql);
+    }
+
+    /**
+     * Compile a multi-path count descriptor using a UNION subquery.
+     *
+     * Each path is compiled into a correlated select subquery that
+     * returns the terminal value for that path. The resulting subqueries
+     * are combined with UNION and counted by an outer scalar subquery.
+     *
+     * This strategy is retained as a generic fallback for multi-path
+     * distinct counts. More specialized strategies, such as EXISTS-based
+     * target counting, may be used by callers when the descriptor shape
+     * allows a more efficient compilation path.
+     *
+     * @param  Descriptor $descriptor
+     * @return Expression
+     */
+    protected function compileUnionCountDescriptor(Descriptor $descriptor): Expression
     {
         if (! $descriptor->distinct()) {
             throw new \RuntimeException(
@@ -539,7 +648,7 @@ abstract class BaseCompiler
             $paths
         );
 
-        $unionSql = implode("\nUNION\n", $subqueries);
+        $unionSql     = implode("\nUNION\n", $subqueries);
         $derivedAlias = SubqueryCompiler::makeSubqueryAlias('count', $paths);
 
         $sql = sprintf(
@@ -725,5 +834,57 @@ abstract class BaseCompiler
             strtoupper($function),
             preg_replace('/[^a-zA-Z0-9_]/', '', $expression)
         );
+    }
+
+    /**
+     * Determine whether a multi-path count descriptor can be compiled
+     * using an EXISTS-based strategy.
+     *
+     * The EXISTS strategy is applicable when all paths terminate on the
+     * same target relation and column (e.g. departments.id). In such cases,
+     * the count can be expressed as:
+     *
+     *   count(*) from target where exists(path1) or exists(path2)
+     *
+     * This avoids UNION-based derived tables and is compatible with MySQL
+     * correlation rules.
+     *
+     * @param  array<int,string> $paths
+     * @return bool
+     */
+    protected function canCompileExistsCountDescriptor(array $paths): bool
+    {
+        if (count($paths) < 2) {
+            return false;
+        }
+
+        $terminal = null;
+
+        foreach ($paths as $path) {
+            $path = trim($path);
+
+            if ($path === '' || ! str_contains($path, '.')) {
+                return false;
+            }
+
+            $parts  = explode('.', $path);
+            $column = array_pop($parts);
+            $target = array_pop($parts);
+
+            if ($column === null || $column === '' || $target === null || $target === '') {
+                return false;
+            }
+
+            if ($terminal === null) {
+                $terminal = [$target, $column];
+                continue;
+            }
+
+            if ($terminal[0] !== $target || $terminal[1] !== $column) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/src/Compilers/SubqueryCompiler.php
+++ b/src/Compilers/SubqueryCompiler.php
@@ -90,6 +90,22 @@ class SubqueryCompiler extends BaseCompiler
     }
 
     /**
+     * Describe a normalized path chain for EXISTS compilation.
+     *
+     * @param  string $path
+     * @return array{
+     *     chain: array<int, array{relation: string, join: string}>,
+     *     field: string|null,
+     *     alias: string|null
+     * }
+     */
+    protected function describePathChain(string $path): array
+    {
+        return $this->outerBuilder->describeColumnChain($path, null, false);
+    }
+
+
+    /**
      * Build a correlated inner query for a single path.
      *
      * The returned query selects the terminal value for the provided path
@@ -166,6 +182,215 @@ class SubqueryCompiler extends BaseCompiler
     public function compilePathSelectSubquerySql(string $path): string
     {
         return $this->buildPathSelectSubquery($path)->toSql();
+    }
+
+    /**
+     * Compile a target-anchored EXISTS count subquery.
+     *
+     * All paths must terminate on the same target relation and field.
+     * The target model becomes the driving table and each path is
+     * compiled into an EXISTS predicate correlated to:
+     *
+     * - the outer record
+     * - the current target row
+     *
+     * Example shape:
+     *
+     *   (
+     *     select count(*)
+     *     from target as T
+     *     where exists(path1 for outer row -> T)
+     *        or exists(path2 for outer row -> T)
+     *   )
+     *
+     * @param  array<int,string> $paths
+     * @return string
+     */
+    public function compileExistsCountSubquerySql(array $paths): string
+    {
+        if ($paths === []) {
+            throw new RuntimeException(
+                'EXISTS count subquery requires at least one path.'
+            );
+        }
+
+        $grammar = $this->builder->getGrammar();
+        $target  = $this->resolveExistsCountTarget($paths);
+        $model   = $this->resolveExistsCountTargetModel($target['chain']);
+        $alias   = $this->outerBuilder->nextSubqueryPrefix() . 'T';
+
+        $predicates = array_map(
+            fn (string $path) => $this->compilePathExistsPredicateSql(
+                $path,
+                $alias,
+                $target['field']
+            ),
+            $paths
+        );
+
+        return sprintf(
+            '(select count(*) from %s as %s where %s)',
+            $grammar->wrapTable($model->getTable()),
+            $grammar->wrap($alias),
+            implode("\nor\n", $predicates)
+        );
+    }
+
+    /**
+     * Compile an EXISTS predicate for a single path.
+     *
+     * The path is resolved from the outer builder base model and
+     * correlated against:
+     *
+     * - the current outer record
+     * - the current target row being counted
+     *
+     * Example shape:
+     *
+     *   exists (
+     *     select 1
+     *     from ...
+     *     where inner_base.id = outer_base.id
+     *       and terminal_value = target_alias.target_field
+     *   )
+     *
+     * @param  string $path
+     * @param  string $targetAlias
+     * @param  string $targetField
+     * @return string
+     */
+    protected function compilePathExistsPredicateSql(
+        string $path,
+        string $targetAlias,
+        string $targetField
+    ): string {
+        $path = trim($path);
+
+        if ($path === '') {
+            throw new RuntimeException(
+                'EXISTS predicate path must not be empty.'
+            );
+        }
+
+        $builder = $this->makeInnerBuilder();
+        $grammar = $builder->getGrammar();
+
+        $column = $this->normalizeColumn($path);
+        $resolved = $builder->resolveColumnExpression($column, null, false);
+        $terminal = $resolved instanceof Expression
+            ? $resolved->getValue($grammar) // @phpstan-ignore-line
+            : (string) $resolved;
+
+        $innerAlias = $builder->getBaseAlias();
+        $innerKey   = $builder->getBaseModel()->getKeyName();
+
+        $builder->select(new CompiledExpression('1'));
+
+        $builder->whereRaw(sprintf(
+            '%s.%s = %s.%s',
+            $grammar->wrap($innerAlias),
+            $grammar->wrap($innerKey),
+            $grammar->wrap($this->getOuterAlias()),
+            $grammar->wrap($this->getOuterKeyName())
+        ));
+
+        $builder->whereRaw(sprintf(
+            '%s = %s.%s',
+            $terminal,
+            $grammar->wrap($targetAlias),
+            $grammar->wrap($targetField)
+        ));
+
+        $query = $builder->getQuery();
+
+        $builder->autoJoinQuery(
+            $query,
+            SubqueryQueryCompiler::class
+        );
+
+        return sprintf(
+            'exists (%s)',
+            $query->toSql()
+        );
+    }
+
+    /**
+     * Resolve the target model for an EXISTS count chain.
+     *
+     * The target model is derived by traversing the normalized chain
+     * from the outer builder base model and returning the related model
+     * of the final relation.
+     *
+     * @param  array<int, array{relation: string, join: string}> $chain
+     * @return \Illuminate\Database\Eloquent\Model
+     */
+    protected function resolveExistsCountTargetModel(array $chain)
+    {
+        $model = $this->outerBuilder->getBaseModel();
+
+        foreach ($chain as $step) {
+            $relation = $step['relation'];
+            $rel      = $model->{$relation}();
+
+            $model = $rel->getRelated();
+        }
+
+        return $model;
+    }
+
+    /**
+     * Resolve the shared terminal target for an EXISTS count.
+     *
+     * All paths must terminate on the same final relation and field.
+     *
+     * @param  array<int,string> $paths
+     * @return array{
+     *     relation: string,
+     *     field: string,
+     *     chain: array<int, array{relation: string, join: string}>
+     * }
+     */
+    protected function resolveExistsCountTarget(array $paths): array
+    {
+        $targetRelation = null;
+        $targetField    = null;
+        $targetChain    = null;
+
+        foreach ($paths as $path) {
+            $parts = $this->describePathChain($this->normalizeColumn($path));
+            $chain = $parts['chain'];
+            $field = $parts['field'];
+
+            if ($chain === [] || ! is_string($field) || $field === '') {
+                throw new RuntimeException(sprintf(
+                    'Invalid EXISTS count path [%s].',
+                    $path
+                ));
+            }
+
+            $final = end($chain);
+            $relation = $final['relation'];
+
+            if ($targetRelation === null) {
+                $targetRelation = $relation;
+                $targetField    = $field;
+                $targetChain    = $chain; // keep first for model resolution
+                continue;
+            }
+
+            if ($targetRelation !== $relation || $targetField !== $field) {
+                throw new RuntimeException(sprintf(
+                    'EXISTS count paths must share the same terminal relation and field. [%s] given.',
+                    $path
+                ));
+            }
+        }
+
+        return [
+            'relation' => $targetRelation,
+            'field'    => $targetField,
+            'chain'    => $targetChain,
+        ];
     }
 
     /**

--- a/src/Traits/AutoJoinQueryBuilderTrait.php
+++ b/src/Traits/AutoJoinQueryBuilderTrait.php
@@ -4,6 +4,12 @@ namespace protich\AutoJoinEloquent\Traits;
 
 use protich\AutoJoinEloquent\AutoJoinQueryBuilder;
 
+/**
+ * Trait: AutoJoinQueryBuilderTrait
+ *
+ * Provide shared factory methods for constructing and configuring
+ * AutoJoinQueryBuilder instances.
+ */
 trait AutoJoinQueryBuilderTrait
 {
     /**
@@ -24,29 +30,52 @@ trait AutoJoinQueryBuilderTrait
      * Create and configure a new AutoJoinQueryBuilder instance.
      *
      * This method centralizes the configuration for AutoJoinQueryBuilder,
-     * setting the default join type, simple aliases flag, and debug output flag based
-     * on the model's properties or configuration defaults.
+     * setting the default join type, simple aliases flag, and debug
+     * output flag based on the model's properties or configuration
+     * defaults.
      *
-     * @param \Illuminate\Database\Query\Builder $query
-     * @param string $joinType The join type to use (default 'left').
+     * @param  \Illuminate\Database\Query\Builder $query
+     * @param  string                             $joinType
      * @return AutoJoinQueryBuilder
      */
-    protected function newAutoJoinQueryBuilder($query, string $joinType = 'left'): AutoJoinQueryBuilder
-    {
+    protected function newAutoJoinQueryBuilder(
+        $query,
+        string $joinType = 'left'
+    ): AutoJoinQueryBuilder {
         $builder = new AutoJoinQueryBuilder($query);
 
-        // Set the default join type.
         $builder->setDefaultJoinType($joinType);
 
-        // Determine whether to use simple aliases from the property or config.
-        /**
-         * @var bool $useSimple
-         */
-        $useSimple = $this->useSimpleAliases ?: config('auto_join_eloquent.use_simple_aliases', true);
-        $builder->setUseSimpleAliases($useSimple);
+        /** @var bool $useSimple */
+        $useSimple = $this->useSimpleAliases
+            ?: config('auto_join_eloquent.use_simple_aliases', true);
 
-        // Set the debug output flag.
-        $builder->debugOutput = $this->debugOutput || (bool)getenv('AUTO_JOIN_DEBUG_SQL');
+        $builder->setUseSimpleAliases($useSimple);
+        $builder->debugOutput = $this->debugOutput || (bool) getenv('AUTO_JOIN_DEBUG_SQL');
+
+        return $builder;
+    }
+
+    /**
+     * Create a new auto-join Eloquent builder.
+     *
+     * The underlying query builder is wrapped in the package-specific
+     * AutoJoinQueryBuilder and a beforeQuery callback is registered so
+     * auto-join processing runs immediately before execution.
+     *
+     * @param  \Illuminate\Database\Query\Builder $query
+     * @param  string                             $joinType
+     * @return AutoJoinQueryBuilder
+     */
+    public function newAutoJoinBuilder(
+        $query,
+        string $joinType = 'left'
+    ): AutoJoinQueryBuilder {
+        $builder = $this->newAutoJoinQueryBuilder($query, $joinType);
+
+        $query->beforeQuery(function ($query) use ($builder) {
+            $builder->autoJoinQuery($query);
+        });
 
         return $builder;
     }

--- a/src/Traits/AutoJoinTrait.php
+++ b/src/Traits/AutoJoinTrait.php
@@ -2,69 +2,26 @@
 
 namespace protich\AutoJoinEloquent\Traits;
 
-use Illuminate\Database\Query\Builder;
 use protich\AutoJoinEloquent\AutoJoinQueryBuilder;
-use RuntimeException;
 
+/**
+ * Trait: AutoJoinTrait
+ *
+ * Override Laravel's default Eloquent builder creation so models return
+ * an AutoJoinQueryBuilder by default.
+ */
 trait AutoJoinTrait
 {
     use AutoJoinQueryBuilderTrait;
 
     /**
-     * Create a new auto-join Eloquent builder.
-     *
-     * The underlying query builder is wrapped in the package-specific
-     * AutoJoinQueryBuilder and a beforeQuery callback is registered so
-     * auto-join processing runs immediately before execution.
-     *
-     * @param  Builder $query
-     * @return AutoJoinQueryBuilder
-     */
-    public function newAutoJoinBuilder($query): AutoJoinQueryBuilder
-    {
-        $builder = $this->newAutoJoinQueryBuilder($query);
-
-        $query->beforeQuery(function (Builder $query) use ($builder) {
-            $builder->autoJoinQuery($query);
-        });
-
-        return $builder;
-    }
-
-    /**
      * Create a new Eloquent builder with auto-join support.
      *
-     * @param  Builder $query
+     * @param  \Illuminate\Database\Query\Builder $query
      * @return AutoJoinQueryBuilder
      */
     public function newEloquentBuilder($query): AutoJoinQueryBuilder
     {
         return $this->newAutoJoinBuilder($query);
-    }
-
-    /**
-     * Describe a model-defined auto-join path.
-     *
-     * Paths prefixed with `model__` are delegated to the model so it can
-     * describe how a logical domain path should be resolved by the
-     * auto-join compiler.
-     *
-     * Models should override this method when they want to support custom
-     * logical paths such as `model__accessibleDepartments` or
-     * `model__status`.
-     *
-     * @param  string            $path
-     * @param  array<int,string> $remainder
-     * @return array<string,mixed>
-     *
-     * @throws RuntimeException
-     */
-    public static function describeAutoJoinPath(string $path, array $remainder): array
-    {
-        throw new RuntimeException(sprintf(
-            'Model [%s] does not support auto-join path [%s].',
-            static::class,
-            $path
-        ));
     }
 }

--- a/src/Traits/QueryJoinerTrait.php
+++ b/src/Traits/QueryJoinerTrait.php
@@ -3,6 +3,15 @@
 namespace protich\AutoJoinEloquent\Traits;
 
 use Illuminate\Database\Query\Builder;
+use RuntimeException;
+
+/**
+ * Trait: QueryJoinerTrait
+ *
+ * Provide manual auto-join query integration and model-defined path
+ * support for models that opt into package behavior without overriding
+ * Laravel's default Eloquent builder.
+ */
 trait QueryJoinerTrait
 {
     use AutoJoinQueryBuilderTrait;
@@ -10,30 +19,43 @@ trait QueryJoinerTrait
     /**
      * Scope a query to manually trigger auto join logic.
      *
-     * This scope method, withAutoJoins, attaches a beforeQuery callback on the underlying query builder.
-     * The callback retrieves the current model from the query and passes it to the AutoJoinQueryBuilder via
-     * setBaseModel() for proper context, then applies auto join logic to add the necessary join clauses.
-     * This enables you to chain withAutoJoins anywhere in the query to manually control the auto joining behavior.
-     *
-     * @param \Illuminate\Database\Eloquent\Builder $query
-     * @param string $joinType The join type to use (default 'left').
+     * @param  \Illuminate\Database\Eloquent\Builder $query
+     * @param  string                                $joinType
      * @return \Illuminate\Database\Eloquent\Builder
      */
     public function scopeWithAutoJoins($query, string $joinType = 'left')
     {
-        // Retrieve the model instance associated with this query.
         $model = $query->getModel();
 
-        // Attach a callback on the underlying query builder that will be executed before the query runs.
-        $query->getQuery()->beforeQuery(function (Builder $q) use ($model, $joinType) {
-            // Create a new, fully configured AutoJoinQueryBuilder for the current query.
-            $builder = $this->newAutoJoinQueryBuilder($q, $joinType);
-            // Pass the model to the builder so it has full context about the base table.
-            $builder->setBaseModel($model);
-            // Apply auto join logic to modify the query's join clauses.
-            $builder->autoJoinQuery($q);
-        });
+        $builder = $model->newAutoJoinBuilder($query->getQuery(), $joinType);
+        $builder->setBaseModel($model);
 
         return $query;
+    }
+
+    /**
+     * Describe a model-defined auto-join path.
+     *
+     * Paths prefixed with `model__` are delegated to the model so it can
+     * describe how a logical domain path should be resolved by the
+     * auto-join compiler.
+     *
+     * Models should override this method when they want to support custom
+     * logical paths such as `model__accessibleDepartments` or
+     * `model__status`.
+     *
+     * @param  string            $path
+     * @param  array<int,string> $remainder
+     * @return array<string,mixed>
+     *
+     * @throws RuntimeException
+     */
+    public static function describeAutoJoinPath(string $path, array $remainder): array
+    {
+        throw new RuntimeException(sprintf(
+            'Model [%s] does not support auto-join path [%s].',
+            static::class,
+            $path
+        ));
     }
 }

--- a/tests/Unit/AccessibleDepartmentsCountTest.php
+++ b/tests/Unit/AccessibleDepartmentsCountTest.php
@@ -9,7 +9,8 @@ use protich\AutoJoinEloquent\Tests\Models\Agent;
  * Test: AccessibleDepartmentsCountTest
  *
  * Verify model-defined accessibleDepartments count descriptors compile
- * and execute across select, order, and having clauses.
+ * and execute across select, order, and having clauses using an
+ * EXISTS-based strategy.
  */
 class AccessibleDepartmentsCountTest extends AutoJoinTestCase
 {
@@ -20,17 +21,16 @@ class AccessibleDepartmentsCountTest extends AutoJoinTestCase
      */
     public function test_select_with_accessible_departments_count(): void
     {
-        $query = Agent::query()
-            ->select([
-                'id',
-                'model__accessibleDepartments__id__count as accessible_departments_count',
-            ]);
+        $query = Agent::query()->select([
+            'id',
+            'model__accessibleDepartments__id__count as accessible_departments_count',
+        ]);
 
         $sql = $this->debugSql($query);
 
         $this->assertStringContainsStringIgnoringCase('select count(*)', $sql);
-        $this->assertStringContainsStringIgnoringCase('union', $sql);
-        $this->assertStringContainsStringIgnoringCase('subquery_count_', $sql);
+        $this->assertStringContainsStringIgnoringCase('exists', $sql);
+        $this->assertStringNotContainsStringIgnoringCase('union', $sql);
         $this->assertStringContainsStringIgnoringCase(
             'as "accessible_departments_count"',
             $sql
@@ -56,8 +56,8 @@ class AccessibleDepartmentsCountTest extends AutoJoinTestCase
         $sql = $this->debugSql($query);
 
         $this->assertStringContainsStringIgnoringCase('order by', $sql);
-        $this->assertStringContainsStringIgnoringCase('union', $sql);
-        $this->assertStringContainsStringIgnoringCase('subquery_count_', $sql);
+        $this->assertStringContainsStringIgnoringCase('accessible_departments_count', $sql);
+        $this->assertStringNotContainsStringIgnoringCase('union', $sql);
 
         $this->assertNonEmptyResults($query->get()->toArray());
     }
@@ -80,8 +80,8 @@ class AccessibleDepartmentsCountTest extends AutoJoinTestCase
         $sql = $this->debugSql($query);
 
         $this->assertStringContainsStringIgnoringCase('having', $sql);
-        $this->assertStringContainsStringIgnoringCase('union', $sql);
-        $this->assertStringContainsStringIgnoringCase('subquery_count_', $sql);
+        $this->assertStringContainsStringIgnoringCase('exists', $sql);
+        $this->assertStringNotContainsStringIgnoringCase('union', $sql);
 
         $this->assertNonEmptyResults($query->get()->toArray());
     }

--- a/tests/Unit/Compiler/AccessibleDepartmentsCountCompilerTest.php
+++ b/tests/Unit/Compiler/AccessibleDepartmentsCountCompilerTest.php
@@ -8,13 +8,13 @@ use protich\AutoJoinEloquent\Tests\Models\Agent;
 /**
  * Test: AccessibleDepartmentsCountCompilerTest
  *
- * Verify accessibleDepartments count compiles through the multi-path
- * subquery pipeline and returns a positive integer result.
+ * Verify accessibleDepartments count compiles through the EXISTS-based
+ * multi-path pipeline and returns a positive integer result.
  */
 class AccessibleDepartmentsCountCompilerTest extends AutoJoinTestCase
 {
     /**
-     * Test accessibleDepartments count compiles using UNION and executes.
+     * Test accessibleDepartments count compiles using EXISTS and executes.
      *
      * @return void
      */
@@ -30,8 +30,9 @@ class AccessibleDepartmentsCountCompilerTest extends AutoJoinTestCase
         $sql = $this->debugSql($query);
         $sqlLower = strtolower($sql);
 
-        $this->assertStringContainsString('union', $sqlLower);
-        $this->assertStringContainsString('subquery_count_', $sqlLower);
+        $this->assertStringContainsString('select count(*)', $sqlLower);
+        $this->assertStringContainsString('exists', $sqlLower);
+        $this->assertStringNotContainsString('union', $sqlLower);
 
         $row = $query->first();
 


### PR DESCRIPTION
This PR introduces an EXISTS-based compilation strategy for multi-path distinct count descriptors, addressing a critical UNION incompatibility with MySQL.

Previously, multi-path counts were implemented by UNION-ing correlated subqueries and wrapping them in a derived table. While this worked in SQLite-based tests, it fails in MySQL because correlated references to outer query aliases are not allowed inside derived tables produced by UNION.

The new approach replaces this pattern with a target-driven EXISTS strategy when all paths terminate on the same relation. Instead of aggregating values via UNION, the query now counts directly from the target table and evaluates each path as an EXISTS predicate.

This produces valid, portable SQL while preserving correctness and improving alignment with relational semantics.

## Why This Change Was Needed
The previous implementation generated queries like:

```sql
select count(*)
from (
  select ...
  where inner.id = outer.id
  union
  select ...
  where inner.id = outer.id
) as t
```

This structure is rejected by MySQL due to the use of correlated references inside a derived table.

The new EXISTS-based approach generates:

```sql
select count(*)
from target t
where exists (path1 from outer -> t)
   or exists (path2 from outer -> t)
```

This avoids invalid correlation patterns, maintains distinctness naturally, and works across supported database engines.

## Changes
- Introduce EXISTS-based compilation for multi-path distinct counts
- Detect eligible descriptor shapes (shared terminal relation + field)
- Retain UNION-based strategy as a fallback for other cases
- Reuse builder chain parsing logic for path normalization
- Centralize auto-join builder creation across traits
- Update tests to reflect EXISTS-based compilation (remove UNION expectations)

## Notes
- This is not an engine-specific branch; it is a strategy improvement based on descriptor shape
- UNION-based compilation remains supported where applicable
- ORDER BY alias reuse continues to work as expected
- HAVING behavior remains unchanged

## Impact
- Fixes MySQL compatibility for model-defined multi-path counts
- Improves correctness and performance characteristics for shared-target counts
- Simplifies SQL generation by aligning with relational intent (existence vs projection)