### PR TITLE
feat(auto-join): resolve expressions at owning model hops

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ composer require protich/auto-join-eloquent
 - PHP 8.3
 - Illuminate Database 13
 
-Version 0.10 supports `BelongsTo`, `HasOne`, `HasMany`, and
+Version 0.11 supports `BelongsTo`, `HasOne`, `HasMany`, and
 `BelongsToMany` relationships. Other Eloquent relationship types, including
 `HasOneThrough` and `HasManyThrough`, fail with an explicit unsupported-type
 exception before join compilation.
@@ -130,9 +130,11 @@ This query compiles the raw SQL and correctly applies the aggregate condition.
 
 ### Model-Defined Paths
 
-Expressions beginning with `model__` are delegated to the base model as one
-complete path. The package does not split or interpret the path before calling
-the model.
+Normal fields and Eloquent relationships are resolved first. When the package
+reaches a path segment it cannot resolve, it asks the model at that hop to
+describe the complete unresolved remainder. A model returns `null` when it
+does not own that expression, preserving the package's permissive handling of
+unknown columns and literal expressions.
 
 ```php
 use protich\AutoJoinEloquent\Model\ExpressionDescriptor;
@@ -140,27 +142,29 @@ use protich\AutoJoinEloquent\Model\PathRequest;
 
 public static function describeAutoJoinPath(
     PathRequest $request
-): ExpressionDescriptor {
+): ?ExpressionDescriptor {
     return match ($request->path) {
-        'model__status' => ExpressionDescriptor::path('flags'),
+        'status' => ExpressionDescriptor::path('flags'),
 
-        'model__accessibleDepartments__id__count' =>
+        'accessibleDepartments__id__count' =>
             ExpressionDescriptor::count([
                 'departments.id',
                 'groups.departments.id',
             ], distinct: true),
 
-        default => throw new \RuntimeException(sprintf(
-            'Unsupported auto-join path [%s].',
-            $request->path
-        )),
+        default => null,
     };
 }
 ```
 
 The returned `ExpressionDescriptor` tells the package how to compile the
-logical expression. Models only need this hook for paths carrying the
-`model__` marker.
+logical expression. For example,
+`organization__cdata__field_id__42` traverses `organization` and `cdata`
+normally, then offers only `field_id__42` to the CData model.
+
+The optional `model__` marker remains supported as an explicit compatibility
+escape hatch. It asks the base model first and, when declined, follows the same
+hop-local fallback behavior.
 
 ### Complex Relationships
 
@@ -210,8 +214,9 @@ provide a partial description.
 
 ## Upgrading
 
-Version 0.10 introduces breaking model API and runtime changes. Applications
-upgrading from 0.9 should follow [UPGRADING.md](UPGRADING.md).
+Version 0.11 adds implicit, hop-local model expression resolution and makes
+the model hook nullable. Applications upgrading from earlier versions should
+follow [UPGRADING.md](UPGRADING.md).
 
 ## Configuration
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,58 @@
 # Upgrading Auto Join Eloquent
 
+## From 0.10 to 0.11
+
+Version 0.11 resolves normal columns and relationships before asking the model
+at the first unresolved hop to describe the remaining path. Update the package
+constraint in consuming applications:
+
+```json
+{
+  "require": {
+    "protich/auto-join-eloquent": "^0.11.0"
+  }
+}
+```
+
+### Return null for expressions the model does not own
+
+The model hook is now nullable. Replace exceptions used only to decline an
+unknown expression with `null`:
+
+```php
+public static function describeAutoJoinPath(
+    PathRequest $request
+): ?ExpressionDescriptor {
+    return match ($request->path) {
+        'status' => ExpressionDescriptor::path('flags'),
+        default => null,
+    };
+}
+```
+
+Validation failures for expressions the model does recognize should still
+throw an exception.
+
+### Describe only the unresolved local remainder
+
+Normal relationships no longer need to be repeated inside a base model's
+descriptor. Given:
+
+```text
+organization__cdata__field_id__42
+```
+
+the package traverses `organization` and `cdata`, then calls the CData model
+with `PathRequest('field_id__42')`. Its descriptor is relative to that model:
+
+```php
+return ExpressionDescriptor::path('values.field_value');
+```
+
+The package rebases the returned path onto the relationships already resolved.
+The `model__` prefix remains supported for compatibility and explicit
+delegation.
+
 ## From 0.9 to 0.10
 
 Version 0.10 targets PHP 8.3 and Illuminate Database 13. Update the package
@@ -35,7 +88,7 @@ public static function describeAutoJoinPath(
     PathRequest $request
 ): ExpressionDescriptor {
     return match ($request->path) {
-        'model__status' => ExpressionDescriptor::path('flags'),
+        'status' => ExpressionDescriptor::path('flags'),
         default => throw new \RuntimeException(sprintf(
             'Unsupported auto-join path [%s].',
             $request->path

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "protich/auto-join-eloquent",
   "description": "Extend Eloquent to support auto-joining relationships and aliasing for SELECT, WHERE, ORDERBY, GROUPBY and HAVING clauses",
   "type": "library",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "license": "MIT",
   "authors": [
     {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,8 +5,3 @@ parameters:
         - tests
     bootstrapFiles:
         - vendor/autoload.php
-    ignoreErrors:
-        -
-            identifier: property.notFound
-        -
-            identifier: property.nonObject

--- a/src/AutoJoinQueryBuilder.php
+++ b/src/AutoJoinQueryBuilder.php
@@ -28,11 +28,11 @@ class AutoJoinQueryBuilder extends EloquentBuilder
     public const MODEL_PATH_PREFIX = 'model__';
 
     /**
-     * Cache for the base model's columns.
+     * Cached table columns used while probing paths at downstream models.
      *
-     * @var array<mixed>|null
+     * @var array<string,list<string>>
      */
-    protected $baseModelColumns = null;
+    protected array $modelColumns = [];
 
     /**
      * Option to use simple sequential aliases.
@@ -618,7 +618,8 @@ class AutoJoinQueryBuilder extends EloquentBuilder
      * @param  string $column
      * @return array{
      *     path:string,
-     *     descriptor:ExpressionDescriptor
+     *     descriptor:ExpressionDescriptor,
+     *     model:class-string<Model>
      * }
      *
      * @throws \InvalidArgumentException If the column is not a valid
@@ -647,20 +648,262 @@ class AutoJoinQueryBuilder extends EloquentBuilder
             ));
         }
 
-        $descriptor = $model->describeAutoJoinPath($request);
+        $descriptor = $this->askModelToDescribePath($model, $request);
 
-        if (! $descriptor instanceof ExpressionDescriptor) {
+        if ($descriptor === null) {
+            $described = $this->describeUnresolvedPath($request->path);
+
+            if ($described !== null) {
+                return $described;
+            }
+
             throw new \RuntimeException(sprintf(
-                'Model [%s] must return an ExpressionDescriptor for auto-join path [%s].',
+                'Model [%s] does not support auto-join path [%s].',
                 $model::class,
-                $column
+                $request->path
             ));
         }
 
         return [
             'path' => $request->path,
             'descriptor' => $descriptor,
+            'model' => $model::class,
         ];
+    }
+
+    /**
+     * Ask the model at the first unresolved hop to describe the remainder.
+     *
+     * Normal columns and relationships take precedence. Returning null means
+     * the expression should continue through the existing permissive compiler
+     * behavior.
+     *
+     * @param  string $column Normalized marker-free column expression.
+     * @return array{
+     *     path:string,
+     *     descriptor:ExpressionDescriptor,
+     *     model:class-string<Model>
+     * }|null
+     */
+    public function describeUnresolvedPath(string $column): ?array
+    {
+        $parsed = $this->parseProbePath($column);
+
+        if ($parsed === null) {
+            return null;
+        }
+
+        $model = $this->getBaseModel();
+        $prefix = [];
+        $lastIndex = count($parsed['segments']) - 1;
+
+        foreach ($parsed['segments'] as $index => $segment) {
+            $isFinal = $index === $lastIndex;
+            $mayBeRelation = count($parsed['segments']) > 1
+                && ! ($isFinal && $parsed['explicitField']);
+
+            if ($mayBeRelation) {
+                $relation = $this->probeRelationship(
+                    $model,
+                    $segment['name']
+                );
+
+                if ($relation !== null) {
+                    $prefix[] = $segment['raw'];
+                    $model = $relation->getRelated();
+                    continue;
+                }
+            }
+
+            if (
+                $isFinal
+                && $this->isModelColumn($model, $segment['name'])
+            ) {
+                return null;
+            }
+
+            $remaining = implode('__', array_column(
+                array_slice($parsed['segments'], $index),
+                'name'
+            ));
+            $request = new PathRequest($remaining);
+            $descriptor = $this->askModelToDescribePath($model, $request);
+
+            if ($descriptor === null) {
+                return null;
+            }
+
+            return [
+                'path' => $request->path,
+                'descriptor' => $this->rebaseDescriptor(
+                    $descriptor,
+                    $prefix
+                ),
+                'model' => $model::class,
+            ];
+        }
+
+        return null;
+    }
+
+    /**
+     * Parse an expression into segments suitable for non-mutating probing.
+     *
+     * @param  string $column
+     * @return array{
+     *     segments:list<array{name:string,raw:string}>,
+     *     explicitField:bool
+     * }|null
+     */
+    protected function parseProbePath(string $column): ?array
+    {
+        $column = trim($column);
+
+        if (
+            $column === ''
+            || $this->isModelDefinedPath($column)
+            || ! preg_match(
+                '/^[A-Za-z_][A-Za-z0-9_]*(?:\|[A-Za-z]+)?'
+                . '(?:__[A-Za-z_][A-Za-z0-9_]*(?:\|[A-Za-z]+)?)*'
+                . '(?:\.[A-Za-z_][A-Za-z0-9_]*)?$/',
+                $column
+            )
+        ) {
+            return null;
+        }
+
+        $dotPosition = strrpos($column, '.');
+        $explicitField = $dotPosition !== false;
+        $chain = $explicitField
+            ? substr($column, 0, $dotPosition)
+            : $column;
+        $segments = array_values(array_filter(explode('__', $chain)));
+
+        if ($explicitField) {
+            $segments[] = substr($column, $dotPosition + 1);
+        }
+
+        $baseTable = $this->getBaseModel()->getTable();
+
+        if (
+            count($segments) > 1
+            && strcasecmp(explode('|', $segments[0], 2)[0], $baseTable) === 0
+        ) {
+            array_shift($segments);
+        }
+
+        if ($segments === []) {
+            return null;
+        }
+
+        return [
+            'segments' => array_map(
+                static function (string $segment): array {
+                    $parts = explode('|', $segment, 2);
+
+                    return [
+                        'name' => $parts[0],
+                        'raw' => $segment,
+                    ];
+                },
+                $segments
+            ),
+            'explicitField' => $explicitField,
+        ];
+    }
+
+    /**
+     * Resolve a relationship for probing without applying its constraints.
+     *
+     * @param  Model  $model
+     * @param  string $name
+     * @return Relation|null
+     */
+    protected function probeRelationship(
+        Model $model,
+        string $name
+    ): ?Relation {
+        if (! method_exists($model, $name)) {
+            return null;
+        }
+
+        try {
+            $relation = Relation::noConstraints(
+                fn () => $model->{$name}()
+            );
+        } catch (\Throwable) {
+            return null;
+        }
+
+        return $relation instanceof Relation ? $relation : null;
+    }
+
+    /**
+     * Ask a model to describe a marker-free path.
+     *
+     * @param  Model       $model
+     * @param  PathRequest $request
+     * @return ExpressionDescriptor|null
+     */
+    protected function askModelToDescribePath(
+        Model $model,
+        PathRequest $request
+    ): ?ExpressionDescriptor {
+        if (! method_exists($model, 'describeAutoJoinPath')) {
+            return null;
+        }
+
+        $descriptor = $model->describeAutoJoinPath($request);
+
+        if (
+            $descriptor !== null
+            && ! $descriptor instanceof ExpressionDescriptor
+        ) {
+            throw new \RuntimeException(sprintf(
+                'Model [%s] must return an ExpressionDescriptor or null for auto-join path [%s].',
+                $model::class,
+                $request->path
+            ));
+        }
+
+        return $descriptor;
+    }
+
+    /**
+     * Rebase a model-relative descriptor onto resolved relationship hops.
+     *
+     * @param  ExpressionDescriptor $descriptor
+     * @param  list<string>         $prefix
+     * @return ExpressionDescriptor
+     */
+    protected function rebaseDescriptor(
+        ExpressionDescriptor $descriptor,
+        array $prefix
+    ): ExpressionDescriptor {
+        if ($prefix === []) {
+            return $descriptor;
+        }
+
+        $prefixPath = implode('__', $prefix);
+        $paths = array_map(
+            static fn (string $path): string =>
+                $prefixPath . '__' . $path,
+            $descriptor->paths()
+        );
+
+        return match ($descriptor->type()) {
+            ExpressionDescriptor::TYPE_PATH =>
+                ExpressionDescriptor::path($paths[0]),
+            ExpressionDescriptor::TYPE_COUNT =>
+                ExpressionDescriptor::count(
+                    $paths,
+                    $descriptor->distinct()
+                ),
+            default => throw new \RuntimeException(sprintf(
+                'Unsupported expression descriptor type [%s].',
+                $descriptor->type()
+            )),
+        };
     }
 
     /**
@@ -1322,14 +1565,39 @@ class AutoJoinQueryBuilder extends EloquentBuilder
      */
     protected function isBaseModelColumn(string $column): bool
     {
-        $model = $this->getBaseModel();
-        if ($this->baseModelColumns === null) {
-            $this->baseModelColumns = $model
-                ->getConnection()
+        return $this->isModelColumn(
+            $this->getBaseModel(),
+            $column
+        );
+    }
+
+    /**
+     * Check whether a physical column exists on a model's table.
+     *
+     * @param  Model  $model
+     * @param  string $column
+     * @return bool
+     */
+    protected function isModelColumn(Model $model, string $column): bool
+    {
+        $connection = $model->getConnection();
+        $cacheKey = sprintf(
+            '%s:%s',
+            $connection->getName(),
+            $model->getTable()
+        );
+
+        if (! isset($this->modelColumns[$cacheKey])) {
+            $this->modelColumns[$cacheKey] = $connection
                 ->getSchemaBuilder()
                 ->getColumnListing($model->getTable());
         }
-        return in_array($column, $this->baseModelColumns ?: [], true);
+
+        return in_array(
+            $column,
+            $this->modelColumns[$cacheKey],
+            true
+        );
     }
 
     /**

--- a/src/AutoJoinQueryBuilder.php
+++ b/src/AutoJoinQueryBuilder.php
@@ -11,7 +11,9 @@ use protich\AutoJoinEloquent\Join\JoinComplexity;
 use protich\AutoJoinEloquent\Model\AutoJoinRelation;
 use protich\AutoJoinEloquent\Model\ExpressionDescriptor;
 use protich\AutoJoinEloquent\Model\PathRequest;
+use protich\AutoJoinEloquent\Support\CompiledExpression;
 
+use Illuminate\Contracts\Database\Query\Expression as ExpressionContract;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Query\Builder as Query;
@@ -20,6 +22,9 @@ use Illuminate\Database\Query\Expression;
 use Illuminate\Database\Query\JoinClause;
 use Illuminate\Support\Facades\Log;
 
+/**
+ * @extends EloquentBuilder<Model>
+ */
 class AutoJoinQueryBuilder extends EloquentBuilder
 {
     /**
@@ -817,7 +822,7 @@ class AutoJoinQueryBuilder extends EloquentBuilder
      *
      * @param  Model  $model
      * @param  string $name
-     * @return Relation|null
+     * @return Relation<Model,Model,mixed>|null
      */
     protected function probeRelationship(
         Model $model,
@@ -927,37 +932,48 @@ class AutoJoinQueryBuilder extends EloquentBuilder
      * @param string|null $alias Optional override for alias parsed from the expression.
      * @param bool $allowAutoAliasing Whether to allow auto-aliasing when the field is inferred.
      * @param string|null $relationshipPath Complete path supplied to relationship hooks.
-     * @return \Illuminate\Database\Query\Expression The resolved SQL expression.
+     * @return CompiledExpression The resolved SQL expression.
      */
     public function resolveColumnExpression(
         string $column,
         ?string $alias = null,
         bool $allowAutoAliasing = true,
         ?string $relationshipPath = null
-    ): Expression {
+    ): CompiledExpression {
         // Parse the column into components: chain, field, and default alias (with auto-aliasing logic)
         $parsed = $this->parseColumnChain($column, $this->getBaseModel()->getTable(), $allowAutoAliasing);
+        $fieldName = $parsed['field'];
+
+        if ($fieldName === null) {
+            throw new \InvalidArgumentException(sprintf(
+                'Column expression [%s] does not contain a field.',
+                $column
+            ));
+        }
 
         // If a relationship chain is present, delegate to auto-join logic
         if (!empty($parsed['chain'])) {
             return $this->resolveAutoJoinExpression(
                 $parsed['chain'],
-                $parsed['field'], // @phpstan-ignore-line
+                $fieldName,
                 $alias ?? $parsed['alias'],
                 $relationshipPath
             );
         }
 
         // No relationship chain: resolve directly on base model
-        $fieldName = $parsed['field'];
         $fieldAlias = $alias ?? $parsed['alias'];
 
         // Add table alias if it's a field on the base model
-        $tableAlias = $this->isBaseModelColumn($fieldName) // @phpstan-ignore-line
+        $tableAlias = $this->isBaseModelColumn($fieldName)
             ? $this->getBaseAlias()
             : null;
 
-        return $this->buildColumnExpression($fieldName, $fieldAlias, $tableAlias); // @phpstan-ignore-line
+        return $this->buildColumnExpression(
+            $fieldName,
+            $fieldAlias,
+            $tableAlias
+        );
     }
 
     /**
@@ -974,7 +990,7 @@ class AutoJoinQueryBuilder extends EloquentBuilder
      * @param string $fieldName The final field name to select.
      * @param string|null $fieldAlias An optional alias to use instead of any parsed alias.
      * @param string|null $relationshipPath Complete path supplied to relationship hooks.
-     * @return \Illuminate\Database\Query\Expression The resolved column expression.
+     * @return CompiledExpression The resolved column expression.
      * @throws \Exception If a relation method is missing or invalid.
      */
     public function resolveAutoJoinExpression(
@@ -982,7 +998,7 @@ class AutoJoinQueryBuilder extends EloquentBuilder
         string $fieldName,
         ?string $fieldAlias = null,
         ?string $relationshipPath = null
-    ): Expression {
+    ): CompiledExpression {
         // Initialize with the base model and its alias.
         $currentModel = $this->getBaseModel();
         $currentAlias = $this->getBaseAlias();
@@ -1155,7 +1171,7 @@ class AutoJoinQueryBuilder extends EloquentBuilder
 
         // Build the table expression for the related table.
         $relatedTable   = $joinInfo->getRelatedTable();
-        $tableExpression = new Expression(sprintf('%s as %s',
+        $tableExpression = new CompiledExpression(sprintf('%s as %s',
             $grammar->wrapTable($relatedTable),
             $grammar->wrap($joinAlias)));
         $joinMethod = $joinInfo->getJoinMethod(); // e.g., 'leftJoin'
@@ -1166,7 +1182,7 @@ class AutoJoinQueryBuilder extends EloquentBuilder
             $tableExpression,
             $joinConditions,
             [
-                'table'    => $tableExpression->getValue($grammar), // @phpstan-ignore-line
+                'table'    => $tableExpression->getValue($grammar),
                 'chainKey' => $context->getChainKey(), // Tagged chain key can be modified as needed.
                 'alias'    => $joinAlias,
             ]
@@ -1227,7 +1243,7 @@ class AutoJoinQueryBuilder extends EloquentBuilder
             )
         );
 
-        $pivotTableExpr = new Expression(sprintf('%s as %s',
+        $pivotTableExpr = new CompiledExpression(sprintf('%s as %s',
             $grammar->wrapTable($pivotTable),
             $grammar->wrap($pivotAlias)));
         $joinMethod     = $joinInfo->getJoinMethod(); // e.g., 'leftJoin'
@@ -1237,7 +1253,7 @@ class AutoJoinQueryBuilder extends EloquentBuilder
             $pivotConditions,
             [
                 'chainKey' => $pivotChainKey,
-                'table'    => $pivotTableExpr->getValue($grammar), // @phpstan-ignore-line
+                'table'    => $pivotTableExpr->getValue($grammar),
                 'alias'    => $pivotAlias
             ]
         );
@@ -1270,7 +1286,7 @@ class AutoJoinQueryBuilder extends EloquentBuilder
             )
         );
 
-        $relatedTableExpr = new Expression(sprintf('%s as %s',
+        $relatedTableExpr = new CompiledExpression(sprintf('%s as %s',
             $grammar->wrapTable($relatedTable),
             $grammar->wrap($relatedAlias)));
         $this->addJoin(
@@ -1279,7 +1295,7 @@ class AutoJoinQueryBuilder extends EloquentBuilder
             $relatedConditions,
             [
                 'chainKey' => $relatedChainKey,
-                'table'    => $relatedTableExpr->getValue($grammar), // @phpstan-ignore-line
+                'table'    => $relatedTableExpr->getValue($grammar),
                 'alias'    => $relatedAlias
             ]
         );
@@ -1301,7 +1317,7 @@ class AutoJoinQueryBuilder extends EloquentBuilder
      * (e.g. "$chainKey . '_pivot'") and an 'alias' key.
      *
      * @param string     $joinMethod      The join method to use (e.g., 'leftJoin', 'join').
-     * @param Expression $tableExpression The table expression (with alias) to join.
+     * @param ExpressionContract $tableExpression The table expression (with alias) to join.
      * @param list<
      *     array{
      *         type:'column',
@@ -1324,7 +1340,12 @@ class AutoJoinQueryBuilder extends EloquentBuilder
      * @param array<string, mixed>      $context         Optional context information for tracking purposes.
      * @return void
      */
-    protected function addJoin(string $joinMethod, $tableExpression, array $conditions, array $context = []): void
+    protected function addJoin(
+        string $joinMethod,
+        ExpressionContract $tableExpression,
+        array $conditions,
+        array $context = []
+    ): void
     {
         // Retrieve the current query builder instance.
         $query = $this->getQuery();
@@ -1387,9 +1408,13 @@ class AutoJoinQueryBuilder extends EloquentBuilder
      * @param string $columnName The name of the column/field.
      * @param string|null $columnAlias Optional alias for the column.
      * @param string|null $tableAlias Optional table alias; if provided, the column is prefixed with this alias.
-     * @return \Illuminate\Database\Query\Expression The constructed SQL expression.
+     * @return CompiledExpression The constructed SQL expression.
      */
-    protected function buildColumnExpression(string $columnName, ?string $columnAlias = null, ?string $tableAlias = null)
+    protected function buildColumnExpression(
+        string $columnName,
+        ?string $columnAlias = null,
+        ?string $tableAlias = null
+    ): CompiledExpression
     {
         $grammar = $this->getGrammar();
 
@@ -1408,7 +1433,7 @@ class AutoJoinQueryBuilder extends EloquentBuilder
             $expression = sprintf('%s as %s', $expression, $grammar->wrap($columnAlias));
         }
 
-        return new Expression($expression);
+        return new CompiledExpression($expression);
     }
     /**
      * Ask the model to resolve and describe a relationship.
@@ -1528,7 +1553,7 @@ class AutoJoinQueryBuilder extends EloquentBuilder
                 ));
             }
 
-            $left = new Expression(sprintf(
+            $left = new CompiledExpression(sprintf(
                 '%s.%s',
                 $grammar->wrap($alias),
                 $grammar->wrap($constraint['column'])
@@ -1609,7 +1634,7 @@ class AutoJoinQueryBuilder extends EloquentBuilder
      * further query compilation to the provided query compiler class.
      *
      * @param  Query                          $query
-     * @param  class-string<QueryCompiler>|null $queryCompilerClass
+     * @param  class-string|null $queryCompilerClass
      * @return void
      */
     public function autoJoinQuery(
@@ -1635,21 +1660,28 @@ class AutoJoinQueryBuilder extends EloquentBuilder
         $grammar = $this->getGrammar();
         $from = $query->from;
 
-        if ($from instanceof Expression) {
-            $from = $from->getValue($grammar); // @phpstan-ignore-line
+        if ($from instanceof ExpressionContract) {
+            $from = $from->getValue($grammar);
         }
 
-        $alias = $this->parseAlias((string) $from);
+        if (! is_string($from)) {
+            throw new \RuntimeException(sprintf(
+                'Auto-join FROM expressions must resolve to SQL strings; [%s] given.',
+                get_debug_type($from)
+            ));
+        }
+
+        $alias = $this->parseAlias($from);
 
         if ($alias !== null) {
             $this->setBaseAlias($alias);
         }
 
-        $query->from = new Expression(sprintf(
+        $query->from(new CompiledExpression(sprintf(
             '%s as %s',
             $grammar->wrapTable($this->getBaseTable()),
             $grammar->wrap($this->getBaseAlias())
-        ));
+        )));
 
         $queryCompilerClass ??= QueryCompiler::class;
 
@@ -1660,7 +1692,7 @@ class AutoJoinQueryBuilder extends EloquentBuilder
             ));
         }
 
-        if (!is_a($queryCompilerClass, QueryCompiler::class, true)) {
+        if (! is_a($queryCompilerClass, QueryCompiler::class, true)) {
             throw new \RuntimeException(sprintf(
                 'Query compiler class [%s] must extend %s.',
                 $queryCompilerClass,

--- a/src/AutoJoinQueryBuilder.php
+++ b/src/AutoJoinQueryBuilder.php
@@ -22,6 +22,10 @@ use Illuminate\Support\Facades\Log;
 
 class AutoJoinQueryBuilder extends EloquentBuilder
 {
+    /**
+     * Prefix that routes a query expression to its model for description.
+     */
+    public const MODEL_PATH_PREFIX = 'model__';
 
     /**
      * Cache for the base model's columns.
@@ -57,6 +61,24 @@ class AutoJoinQueryBuilder extends EloquentBuilder
      * @var array<string,AutoJoinRelation>
      */
     protected array $resolvedRelationships = [];
+
+    /**
+     * Resolved chain key for each constraint variant of a relationship chain.
+     *
+     * The first constraint signature keeps the normal chain key. Additional
+     * signatures receive a deterministic suffix so independently constrained
+     * joins do not reuse one another.
+     *
+     * @var array<string,array<string,string>>
+     */
+    protected array $relationshipVariants = [];
+
+    /**
+     * Chain keys resolved for complete triggering relationship paths.
+     *
+     * @var array<string,array<string,string>>
+     */
+    protected array $pathRelationships = [];
 
 
     /**
@@ -584,14 +606,14 @@ class AutoJoinQueryBuilder extends EloquentBuilder
      */
     public function isModelDefinedPath(string $column): bool
     {
-        return str_starts_with($column, 'model__');
+        return str_starts_with($column, self::MODEL_PATH_PREFIX);
     }
 
     /**
      * Resolve the model-defined path descriptor for the given column.
      *
-     * The complete path is delegated to the model without package-level
-     * segmentation or interpretation.
+     * The reserved marker is removed before the complete application-defined
+     * path is delegated without package-level segmentation or interpretation.
      *
      * @param  string $column
      * @return array{
@@ -613,7 +635,9 @@ class AutoJoinQueryBuilder extends EloquentBuilder
             ));
         }
 
-        $model = $this->getBaseModel();
+        $model   = $this->getBaseModel();
+        $path    = substr($column, strlen(self::MODEL_PATH_PREFIX));
+        $request = new PathRequest($path);
 
         if (! method_exists($model, 'describeAutoJoinPath')) {
             throw new \RuntimeException(sprintf(
@@ -623,9 +647,7 @@ class AutoJoinQueryBuilder extends EloquentBuilder
             ));
         }
 
-        $descriptor = $model->describeAutoJoinPath(
-            new PathRequest($column)
-        );
+        $descriptor = $model->describeAutoJoinPath($request);
 
         if (! $descriptor instanceof ExpressionDescriptor) {
             throw new \RuntimeException(sprintf(
@@ -636,7 +658,7 @@ class AutoJoinQueryBuilder extends EloquentBuilder
         }
 
         return [
-            'path' => $column,
+            'path' => $request->path,
             'descriptor' => $descriptor,
         ];
     }
@@ -661,12 +683,15 @@ class AutoJoinQueryBuilder extends EloquentBuilder
      * @param string $column The raw column expression (e.g., "agent.id as agent_id", "agent__manager__user").
      * @param string|null $alias Optional override for alias parsed from the expression.
      * @param bool $allowAutoAliasing Whether to allow auto-aliasing when the field is inferred.
+     * @param string|null $relationshipPath Complete path supplied to relationship hooks.
      * @return \Illuminate\Database\Query\Expression The resolved SQL expression.
      */
-    public function resolveColumnExpression( string $column,
+    public function resolveColumnExpression(
+        string $column,
         ?string $alias = null,
-        bool $allowAutoAliasing = true): Expression
-    {
+        bool $allowAutoAliasing = true,
+        ?string $relationshipPath = null
+    ): Expression {
         // Parse the column into components: chain, field, and default alias (with auto-aliasing logic)
         $parsed = $this->parseColumnChain($column, $this->getBaseModel()->getTable(), $allowAutoAliasing);
 
@@ -675,7 +700,8 @@ class AutoJoinQueryBuilder extends EloquentBuilder
             return $this->resolveAutoJoinExpression(
                 $parsed['chain'],
                 $parsed['field'], // @phpstan-ignore-line
-                $alias ?? $parsed['alias']
+                $alias ?? $parsed['alias'],
+                $relationshipPath
             );
         }
 
@@ -704,36 +730,55 @@ class AutoJoinQueryBuilder extends EloquentBuilder
      * @param string[][] $chain The parsed relationship chain (an array of arrays with keys 'relation' and 'join').
      * @param string $fieldName The final field name to select.
      * @param string|null $fieldAlias An optional alias to use instead of any parsed alias.
+     * @param string|null $relationshipPath Complete path supplied to relationship hooks.
      * @return \Illuminate\Database\Query\Expression The resolved column expression.
      * @throws \Exception If a relation method is missing or invalid.
      */
-    public function resolveAutoJoinExpression(array $chain, string $fieldName, ?string $fieldAlias = null): Expression
-    {
+    public function resolveAutoJoinExpression(
+        array $chain,
+        string $fieldName,
+        ?string $fieldAlias = null,
+        ?string $relationshipPath = null
+    ): Expression {
         // Initialize with the base model and its alias.
         $currentModel = $this->getBaseModel();
         $currentAlias = $this->getBaseAlias();
-        $chainKeyParts = [];
-        $path = sprintf(
+        $chainKey = '';
+        $normalizedPath = sprintf(
             '%s.%s',
             implode('__', array_column($chain, 'relation')),
             $fieldName
         );
+        $path = $relationshipPath ?? $normalizedPath;
+
         // Iterate through each segment in the chain.
         foreach ($chain as $item) {
             $relationName = $item['relation'];
             $joinType = $item['join'];
-            $chainKeyParts[] = $relationName;
-            $chainKey = implode('__', $chainKeyParts);
+            $baseChainKey = ltrim(
+                $chainKey . '__' . $relationName,
+                '_'
+            );
+            $pathChainKey =
+                $this->pathRelationships[$baseChainKey][$path] ?? null;
 
-            if (isset($this->resolvedRelationships[$chainKey])) {
+            if ($pathChainKey !== null) {
+                $chainKey = $pathChainKey;
                 $autoJoinRelation = $this->resolvedRelationships[$chainKey];
             } else {
-                $autoJoinRelation = $this->resolveRelationship(
+                $description = $this->resolveRelationship(
                     $currentModel,
                     $relationName,
                     $path
                 );
+                $chainKey = $this->resolveRelationshipVariantKey(
+                    $baseChainKey,
+                    $description
+                );
+                $autoJoinRelation = $this->resolvedRelationships[$chainKey]
+                    ?? $description;
                 $this->resolvedRelationships[$chainKey] = $autoJoinRelation;
+                $this->pathRelationships[$baseChainKey][$path] = $chainKey;
             }
 
             $relation = $autoJoinRelation->relation();
@@ -762,6 +807,45 @@ class AutoJoinQueryBuilder extends EloquentBuilder
 
         // Build the final column expression using the resolved alias.
         return $this->buildColumnExpression($fieldName, $fieldAlias, $currentAlias);
+    }
+
+    /**
+     * Resolve a join-chain key for a relationship constraint signature.
+     *
+     * Repeated descriptions with identical constraints share the same key.
+     * When the same logical chain is described with different constraints,
+     * later variants receive a stable suffix and therefore a distinct join
+     * alias.
+     *
+     * @param  string           $baseChainKey Logical relationship chain.
+     * @param  AutoJoinRelation $description  Model-authored description.
+     * @return string
+     */
+    protected function resolveRelationshipVariantKey(
+        string $baseChainKey,
+        AutoJoinRelation $description
+    ): string {
+        $signature = hash(
+            'sha256',
+            serialize($description->constraints())
+        );
+        $variants = $this->relationshipVariants[$baseChainKey] ?? [];
+
+        if (isset($variants[$signature])) {
+            return $variants[$signature];
+        }
+
+        $chainKey = $variants === []
+            ? $baseChainKey
+            : sprintf(
+                '%s__%s',
+                $baseChainKey,
+                substr($signature, 0, 12)
+            );
+
+        $this->relationshipVariants[$baseChainKey][$signature] = $chainKey;
+
+        return $chainKey;
     }
 
     /**
@@ -1093,7 +1177,7 @@ class AutoJoinQueryBuilder extends EloquentBuilder
      *
      * @param  Model     $model        Model that owns the relationship.
      * @param  string    $relationName Relationship method name.
-     * @param  string    $path         Complete normalized query path.
+     * @param  string    $path         Complete path that triggered the join.
      * @return AutoJoinRelation
      *
      * @throws \RuntimeException If the model returns an invalid description or
@@ -1270,6 +1354,8 @@ class AutoJoinQueryBuilder extends EloquentBuilder
         if ($this->getQuery() !== $query) {
             $this->autoJoinedRelations = [];
             $this->resolvedRelationships = [];
+            $this->relationshipVariants = [];
+            $this->pathRelationships = [];
             $this->aliasManager = new JoinAliasManager($this->useSimpleAliases);
             $this->selectAliases = [];
             $this->subqueryCounter = 0;

--- a/src/Compilers/BaseCompiler.php
+++ b/src/Compilers/BaseCompiler.php
@@ -368,14 +368,23 @@ abstract class BaseCompiler
      *     alias: string|null,
      *     distinct?: bool
      * } $info
-     * @param bool $useDefaultAlias
+     * @param  bool        $useDefaultAlias
+     * @param  string|null $relationshipPath
      * @return Expression
      */
-    protected function compileAggregateExpression(array $info, bool $useDefaultAlias = false): Expression
-    {
+    protected function compileAggregateExpression(
+        array $info,
+        bool $useDefaultAlias = false,
+        ?string $relationshipPath = null
+    ): Expression {
         $grammar  = $this->builder->getGrammar();
         $parsed   = $this->parseColumnParts($info['innerExpression']);
-        $resolved = $this->resolveColumnExpression($parsed['column'], null, false);
+        $resolved = $this->resolveColumnExpression(
+            $parsed['column'],
+            null,
+            false,
+            $relationshipPath
+        );
 
         $innerSql = $resolved->getValue($grammar); // @phpstan-ignore-line
         $distinct = (bool) ($info['distinct'] ?? false);
@@ -518,12 +527,14 @@ abstract class BaseCompiler
             ExpressionDescriptor::TYPE_PATH => $this->compileModelPathDescriptor(
                 $descriptor,
                 $alias,
-                $allowAlias
+                $allowAlias,
+                $modelPath['path']
             ),
             ExpressionDescriptor::TYPE_COUNT => $this->compileModelCountDescriptor(
                 $descriptor,
                 $alias,
-                $allowAlias
+                $allowAlias,
+                $modelPath['path']
             ),
             default => throw new \RuntimeException(sprintf(
                 'Unsupported model-defined descriptor type [%s] for path [%s].',
@@ -536,17 +547,22 @@ abstract class BaseCompiler
     /**
      * Compile a model-defined path descriptor of type `path`.
      *
-     * @param  ExpressionDescriptor  $descriptor
+     * @param  ExpressionDescriptor $descriptor
+     * @param  string|null          $alias
+     * @param  bool                 $allowAlias
+     * @param  string               $sourcePath
      */
     protected function compileModelPathDescriptor(
         ExpressionDescriptor $descriptor,
         ?string $alias,
-        bool $allowAlias
+        bool $allowAlias,
+        string $sourcePath
     ): Expression {
         return $this->builder->resolveColumnExpression(
             $descriptor->getPath(), // @phpstan-ignore-line
             $allowAlias ? $alias : null,
-            $allowAlias
+            $allowAlias,
+            $sourcePath
         );
     }
 
@@ -556,29 +572,38 @@ abstract class BaseCompiler
      * Single-path counts reuse the normal aggregate compiler. Multi-path
      * counts are compiled through correlated subqueries and UNION.
      *
-     * @param  ExpressionDescriptor  $descriptor
+     * @param  ExpressionDescriptor $descriptor
+     * @param  string|null          $alias
+     * @param  bool                 $allowAlias
+     * @param  string               $sourcePath
      */
     protected function compileModelCountDescriptor(
         ExpressionDescriptor $descriptor,
         ?string $alias,
-        bool $allowAlias
+        bool $allowAlias,
+        string $sourcePath
     ): Expression {
         $paths = $descriptor->paths();
 
         if (count($paths) === 1) {
-            return $this->compileAggregateExpression([
-                'aggregateFunction' => 'COUNT',
-                'innerExpression'   => $paths[0],
-                'alias'             => $allowAlias ? $alias : null,
-                'outerExpression'   => '',
-                'distinct'          => $descriptor->distinct(),
-            ], $allowAlias && $alias === null);
+            return $this->compileAggregateExpression(
+                [
+                    'aggregateFunction' => 'COUNT',
+                    'innerExpression'   => $paths[0],
+                    'alias'             => $allowAlias ? $alias : null,
+                    'outerExpression'   => '',
+                    'distinct'          => $descriptor->distinct(),
+                ],
+                $allowAlias && $alias === null,
+                $sourcePath
+            );
         }
 
         return $this->compileMultiPathCountDescriptor(
             $descriptor,
             $allowAlias ? $alias : null,
-            $allowAlias
+            $allowAlias,
+            $sourcePath
         );
     }
 
@@ -589,12 +614,16 @@ abstract class BaseCompiler
      * compiled using an EXISTS-based strategy. All other multi-path counts
      * fall back to the UNION-based strategy.
      *
-     * @param  ExpressionDescriptor  $descriptor
+     * @param  ExpressionDescriptor $descriptor
+     * @param  string|null          $alias
+     * @param  bool                 $allowAlias
+     * @param  string               $sourcePath
      */
     protected function compileMultiPathCountDescriptor(
         ExpressionDescriptor $descriptor,
         ?string $alias,
-        bool $allowAlias
+        bool $allowAlias,
+        string $sourcePath
     ): Expression {
         if (! $descriptor->distinct()) {
             throw new \RuntimeException(
@@ -608,14 +637,16 @@ abstract class BaseCompiler
             return $this->compileExistsCountDescriptor(
                 $descriptor,
                 $alias,
-                $allowAlias
+                $allowAlias,
+                $sourcePath
             );
         }
 
         return $this->compileUnionCountDescriptor(
             $descriptor,
             $alias,
-            $allowAlias
+            $allowAlias,
+            $sourcePath
         );
     }
 
@@ -640,12 +671,16 @@ abstract class BaseCompiler
      * This avoids UNION-based correlated derived tables and is compatible
      * with MySQL correlation rules.
      *
-     * @param  ExpressionDescriptor  $descriptor
+     * @param  ExpressionDescriptor $descriptor
+     * @param  string|null          $alias
+     * @param  bool                 $allowAlias
+     * @param  string               $sourcePath
      */
     protected function compileExistsCountDescriptor(
         ExpressionDescriptor $descriptor,
         ?string $alias,
-        bool $allowAlias
+        bool $allowAlias,
+        string $sourcePath
     ): Expression {
         if (! $descriptor->distinct()) {
             throw new \RuntimeException(
@@ -657,7 +692,10 @@ abstract class BaseCompiler
         $grammar  = $this->builder->getGrammar();
         $compiler = new SubqueryCompiler($this->builder);
 
-        $subquery = $compiler->compileExistsCountSubquery($paths);
+        $subquery = $compiler->compileExistsCountSubquery(
+            $paths,
+            $sourcePath
+        );
         $sql = $subquery->sql();
 
         $this->addSubqueryBindings($subquery);
@@ -688,12 +726,16 @@ abstract class BaseCompiler
      * target counting, may be used by callers when the descriptor shape
      * allows a more efficient compilation path.
      *
-     * @param  ExpressionDescriptor  $descriptor
+     * @param  ExpressionDescriptor $descriptor
+     * @param  string|null          $alias
+     * @param  bool                 $allowAlias
+     * @param  string               $sourcePath
      */
     protected function compileUnionCountDescriptor(
         ExpressionDescriptor $descriptor,
         ?string $alias,
-        bool $allowAlias
+        bool $allowAlias,
+        string $sourcePath
     ): Expression {
         if (! $descriptor->distinct()) {
             throw new \RuntimeException(
@@ -706,7 +748,10 @@ abstract class BaseCompiler
 
         $subqueries = array_map(
             fn (string $path) => (new SubqueryCompiler($this->builder))
-                ->compilePathSelectSubquerySqlExpression($path),
+                ->compilePathSelectSubquerySqlExpression(
+                    $path,
+                    $sourcePath
+                ),
             $paths
         );
 
@@ -879,12 +924,14 @@ abstract class BaseCompiler
      * @param  string       $column
      * @param  string|null  $alias
      * @param  bool         $allowAutoAliasing
+     * @param  string|null  $relationshipPath
      * @return Expression
      */
     protected function resolveColumnExpression(
         string $column,
         ?string $alias = null,
-        bool $allowAutoAliasing = true
+        bool $allowAutoAliasing = true,
+        ?string $relationshipPath = null
     ): Expression {
         if ($modelPath = $this->parseModelDefinedPathExpression($column)) {
             if ($alias !== null && empty($modelPath['alias'])) {
@@ -900,7 +947,8 @@ abstract class BaseCompiler
         return $this->builder->resolveColumnExpression(
             $column,
             $alias,
-            $allowAutoAliasing
+            $allowAutoAliasing,
+            $relationshipPath
         );
     }
 

--- a/src/Compilers/BaseCompiler.php
+++ b/src/Compilers/BaseCompiler.php
@@ -22,6 +22,13 @@ use Illuminate\Database\Query\Expression;
 abstract class BaseCompiler
 {
     /**
+     * Model-described paths currently being compiled.
+     *
+     * @var list<string>
+     */
+    protected array $describedPathStack = [];
+
+    /**
      * Laravel binding group for expressions compiled by this compiler.
      *
      * @var string
@@ -130,7 +137,7 @@ abstract class BaseCompiler
      * - Aggregates (COUNT(...), SUM(...))
      * - Suffix-based aggregates (e.g., __count)
      * - COALESCE(...)
-     * - Model-defined paths (e.g., model__status)
+     * - Model-described paths (e.g., status or model__status)
      * - Basic relationship-aware columns
      *
      * @param string $column
@@ -139,10 +146,24 @@ abstract class BaseCompiler
      */
     public function compileColumn(string $column, bool $allowAlias = false): Expression
     {
-        if ($modelPath = $this->parseModelDefinedPathExpression($column)) {
+        if ($modelPath = $this->parseDescribedPathExpression($column)) {
             return $this->compileModelDefinedPath($modelPath, $allowAlias);
         }
 
+        return $this->compileStandardColumn($column, $allowAlias);
+    }
+
+    /**
+     * Compile expressions that were not described by a model.
+     *
+     * @param  string $column
+     * @param  bool   $allowAlias
+     * @return Expression
+     */
+    protected function compileStandardColumn(
+        string $column,
+        bool $allowAlias = false
+    ): Expression {
         if ($aggregate = $this->parseAggregateExpression($column)) {
             return $this->compileAggregateExpression($aggregate, $allowAlias);
         }
@@ -464,7 +485,7 @@ abstract class BaseCompiler
 
         $resolved = array_map(function ($field) use ($grammar) {
             $column = $this->parseColumnParts($field)['column'];
-            $expr = $this->builder->resolveColumnExpression($column, null, false);
+            $expr = $this->resolveColumnExpression($column, null, false);
             // @phpstan-ignore-next-line
             return $expr->getValue($grammar); // @phpstan-ignore-line
         }, $info['fields']);
@@ -487,6 +508,7 @@ abstract class BaseCompiler
      * @return array{
      *     path:string,
      *     descriptor:ExpressionDescriptor,
+     *     model:class-string<\Illuminate\Database\Eloquent\Model>,
      *     alias:?string
      * }|null
      */
@@ -503,8 +525,58 @@ abstract class BaseCompiler
         return [
             'path'       => $described['path'],
             'descriptor' => $described['descriptor'],
+            'model'      => $described['model'],
             'alias'      => $parsed['alias'] ?? null,
         ];
+    }
+
+    /**
+     * Parse an implicitly model-described path expression.
+     *
+     * @param  string $column
+     * @return array{
+     *     path:string,
+     *     descriptor:ExpressionDescriptor,
+     *     model:class-string<\Illuminate\Database\Eloquent\Model>,
+     *     alias:?string
+     * }|null
+     */
+    protected function parseImplicitModelPathExpression(
+        string $column
+    ): ?array {
+        $parsed = $this->parseColumnParts($column);
+        $described = $this->builder->describeUnresolvedPath(
+            $parsed['column']
+        );
+
+        if ($described === null) {
+            return null;
+        }
+
+        return [
+            'path'       => $described['path'],
+            'descriptor' => $described['descriptor'],
+            'model'      => $described['model'],
+            'alias'      => $parsed['alias'] ?? null,
+        ];
+    }
+
+    /**
+     * Parse either an explicit or implicitly model-described expression.
+     *
+     * @param  string $column
+     * @return array{
+     *     path:string,
+     *     descriptor:ExpressionDescriptor,
+     *     model:class-string<\Illuminate\Database\Eloquent\Model>,
+     *     alias:?string
+     * }|null
+     */
+    protected function parseDescribedPathExpression(
+        string $column
+    ): ?array {
+        return $this->parseModelDefinedPathExpression($column)
+            ?? $this->parseImplicitModelPathExpression($column);
     }
 
     /**
@@ -513,6 +585,7 @@ abstract class BaseCompiler
      * @param  array{
      *     path:string,
      *     descriptor:ExpressionDescriptor,
+     *     model:class-string<\Illuminate\Database\Eloquent\Model>,
      *     alias:?string
      * } $modelPath
      * @param  bool $allowAlias
@@ -522,26 +595,43 @@ abstract class BaseCompiler
     {
         $descriptor = $modelPath['descriptor'];
         $alias = $modelPath['alias'] ?? null;
+        $stackKey = $modelPath['model'] . '::' . $modelPath['path'];
 
-        return match ($descriptor->type()) {
-            ExpressionDescriptor::TYPE_PATH => $this->compileModelPathDescriptor(
-                $descriptor,
-                $alias,
-                $allowAlias,
-                $modelPath['path']
-            ),
-            ExpressionDescriptor::TYPE_COUNT => $this->compileModelCountDescriptor(
-                $descriptor,
-                $alias,
-                $allowAlias,
-                $modelPath['path']
-            ),
-            default => throw new \RuntimeException(sprintf(
-                'Unsupported model-defined descriptor type [%s] for path [%s].',
-                $descriptor->type(),
-                $modelPath['path']
-            )),
-        };
+        if (in_array($stackKey, $this->describedPathStack, true)) {
+            throw new \RuntimeException(sprintf(
+                'Circular model-defined auto-join path [%s] on model [%s].',
+                $modelPath['path'],
+                $modelPath['model']
+            ));
+        }
+
+        $this->describedPathStack[] = $stackKey;
+
+        try {
+            return match ($descriptor->type()) {
+                ExpressionDescriptor::TYPE_PATH =>
+                    $this->compileModelPathDescriptor(
+                        $descriptor,
+                        $alias,
+                        $allowAlias,
+                        $modelPath['path']
+                    ),
+                ExpressionDescriptor::TYPE_COUNT =>
+                    $this->compileModelCountDescriptor(
+                        $descriptor,
+                        $alias,
+                        $allowAlias,
+                        $modelPath['path']
+                    ),
+                default => throw new \RuntimeException(sprintf(
+                    'Unsupported model-defined descriptor type [%s] for path [%s].',
+                    $descriptor->type(),
+                    $modelPath['path']
+                )),
+            };
+        } finally {
+            array_pop($this->describedPathStack);
+        }
     }
 
     /**
@@ -558,7 +648,7 @@ abstract class BaseCompiler
         bool $allowAlias,
         string $sourcePath
     ): Expression {
-        return $this->builder->resolveColumnExpression(
+        return $this->resolveColumnExpression(
             $descriptor->getPath(), // @phpstan-ignore-line
             $allowAlias ? $alias : null,
             $allowAlias,
@@ -933,7 +1023,7 @@ abstract class BaseCompiler
         bool $allowAutoAliasing = true,
         ?string $relationshipPath = null
     ): Expression {
-        if ($modelPath = $this->parseModelDefinedPathExpression($column)) {
+        if ($modelPath = $this->parseDescribedPathExpression($column)) {
             if ($alias !== null && empty($modelPath['alias'])) {
                 $modelPath['alias'] = $alias;
             }

--- a/src/Compilers/BaseCompiler.php
+++ b/src/Compilers/BaseCompiler.php
@@ -2,6 +2,7 @@
 
 namespace protich\AutoJoinEloquent\Compilers;
 
+use Illuminate\Contracts\Database\Query\Expression as ExpressionContract;
 use protich\AutoJoinEloquent\AutoJoinQueryBuilder;
 use protich\AutoJoinEloquent\Model\ExpressionDescriptor;
 use protich\AutoJoinEloquent\Support\CompiledExpression;
@@ -98,9 +99,9 @@ abstract class BaseCompiler
             // Compile structured clause arrays.
             if (is_array($clause)) {
                 // ['column' => 'user.id__count']
-                if (isset($clause['column'])) {
+                if (is_string($clause['column'] ?? null)) {
                     $compiledColumn = $this->compileColumn(
-                        (string) $clause['column'] // @phpstan-ignore-line
+                        $clause['column']
                     );
                     $clause['column'] = $compiledColumn;
 
@@ -142,9 +143,12 @@ abstract class BaseCompiler
      *
      * @param string $column
      * @param bool $allowAlias
-     * @return Expression
+     * @return CompiledExpression
      */
-    public function compileColumn(string $column, bool $allowAlias = false): Expression
+    public function compileColumn(
+        string $column,
+        bool $allowAlias = false
+    ): CompiledExpression
     {
         if ($modelPath = $this->parseDescribedPathExpression($column)) {
             return $this->compileModelDefinedPath($modelPath, $allowAlias);
@@ -158,12 +162,12 @@ abstract class BaseCompiler
      *
      * @param  string $column
      * @param  bool   $allowAlias
-     * @return Expression
+     * @return CompiledExpression
      */
     protected function compileStandardColumn(
         string $column,
         bool $allowAlias = false
-    ): Expression {
+    ): CompiledExpression {
         if ($aggregate = $this->parseAggregateExpression($column)) {
             return $this->compileAggregateExpression($aggregate, $allowAlias);
         }
@@ -211,13 +215,12 @@ abstract class BaseCompiler
         if ($bitwise = $this->parseBitwiseExpression($sql)) {
             if ($this->shouldResolveColumn($bitwise['left'])) {
                 $resolved = $this->resolveColumnExpression($bitwise['left'], null, false);
-                // @phpstan-ignore-next-line
-                $left = $resolved instanceof Expression
-                    ? $resolved->getValue($this->builder->getGrammar()) // @phpstan-ignore-line
-                    : (string) $resolved;
+                $left = $resolved->getValue(
+                    $this->builder->getGrammar()
+                );
 
                 return sprintf('%s %s %s',
-                    $left, $bitwise['operator'], $bitwise['right']); // @phpstan-ignore-line
+                    $left, $bitwise['operator'], $bitwise['right']);
             }
         }
 
@@ -347,7 +350,7 @@ abstract class BaseCompiler
             return [
                 'aggregateFunction' => $function,
                 'innerExpression'   => trim($m[1]),
-                'alias'             => isset($m[3]) && $m[3] !== '' ? $m[3] : null, // @phpstan-ignore-line
+                'alias'             => $m[3] ?? null,
                 'outerExpression'   => '',
             ];
         }
@@ -371,7 +374,7 @@ abstract class BaseCompiler
     {
         $expr = $this->compileAggregateExpression($info, false);
 
-        $sql = $expr->getValue($this->builder->getGrammar()); // @phpstan-ignore-line
+        $sql = $expr->getValue($this->builder->getGrammar());
 
         if (! empty($info['outerExpression'])) {
             $sql .= ' ' . (string) $info['outerExpression'];
@@ -391,13 +394,13 @@ abstract class BaseCompiler
      * } $info
      * @param  bool        $useDefaultAlias
      * @param  string|null $relationshipPath
-     * @return Expression
+     * @return CompiledExpression
      */
     protected function compileAggregateExpression(
         array $info,
         bool $useDefaultAlias = false,
         ?string $relationshipPath = null
-    ): Expression {
+    ): CompiledExpression {
         $grammar  = $this->builder->getGrammar();
         $parsed   = $this->parseColumnParts($info['innerExpression']);
         $resolved = $this->resolveColumnExpression(
@@ -407,20 +410,20 @@ abstract class BaseCompiler
             $relationshipPath
         );
 
-        $innerSql = $resolved->getValue($grammar); // @phpstan-ignore-line
+        $innerSql = $resolved->getValue($grammar);
         $distinct = (bool) ($info['distinct'] ?? false);
 
         $alias = $info['alias']
             ?? ($useDefaultAlias
                 ? $this->makeAggregateAlias($info['aggregateFunction'], $innerSql)
-                : null); // @phpstan-ignore-line
+                : null);
 
         $sql = sprintf(
             '%s(%s%s)',
             $info['aggregateFunction'],
             $distinct ? 'DISTINCT ' : '',
             $innerSql
-        ); // @phpstan-ignore-line
+        );
 
         return $this->makeCompiledExpression($sql, $alias);
     }
@@ -463,31 +466,32 @@ abstract class BaseCompiler
     protected function compileCoalesce(array $info): string
     {
         $expr = $this->compileCoalesceExpression($info);
-        // @phpstan-ignore-next-line
         $sql = $expr->getValue($this->builder->getGrammar());
 
         if (!empty($info['outerExpression'])) {
-            $sql .= ' ' . (string) $info['outerExpression']; // @phpstan-ignore-line
+            $sql .= ' ' . $info['outerExpression'];
         }
 
-        return $sql; // @phpstan-ignore-line
+        return $sql;
     }
 
     /**
      * Compile a COALESCE(...) expression into a wrapped Expression.
      *
      * @param array{fields: string[], alias: string|null} $info
-     * @return Expression
+     * @return CompiledExpression
      */
-    protected function compileCoalesceExpression(array $info): Expression
+    protected function compileCoalesceExpression(
+        array $info
+    ): CompiledExpression
     {
         $grammar = $this->builder->getGrammar();
 
-        $resolved = array_map(function ($field) use ($grammar) {
+        $resolved = array_map(function (string $field) use ($grammar): string {
             $column = $this->parseColumnParts($field)['column'];
             $expr = $this->resolveColumnExpression($column, null, false);
-            // @phpstan-ignore-next-line
-            return $expr->getValue($grammar); // @phpstan-ignore-line
+
+            return $expr->getValue($grammar);
         }, $info['fields']);
 
         $sql = 'COALESCE(' . implode(', ', $resolved) . ')';
@@ -589,9 +593,12 @@ abstract class BaseCompiler
      *     alias:?string
      * } $modelPath
      * @param  bool $allowAlias
-     * @return Expression
+     * @return CompiledExpression
      */
-    protected function compileModelDefinedPath(array $modelPath, bool $allowAlias = false): Expression
+    protected function compileModelDefinedPath(
+        array $modelPath,
+        bool $allowAlias = false
+    ): CompiledExpression
     {
         $descriptor = $modelPath['descriptor'];
         $alias = $modelPath['alias'] ?? null;
@@ -641,15 +648,24 @@ abstract class BaseCompiler
      * @param  string|null          $alias
      * @param  bool                 $allowAlias
      * @param  string               $sourcePath
+     * @return CompiledExpression
      */
     protected function compileModelPathDescriptor(
         ExpressionDescriptor $descriptor,
         ?string $alias,
         bool $allowAlias,
         string $sourcePath
-    ): Expression {
+    ): CompiledExpression {
+        $path = $descriptor->getPath();
+
+        if ($path === null) {
+            throw new \LogicException(
+                'A path descriptor must contain a path.'
+            );
+        }
+
         return $this->resolveColumnExpression(
-            $descriptor->getPath(), // @phpstan-ignore-line
+            $path,
             $allowAlias ? $alias : null,
             $allowAlias,
             $sourcePath
@@ -666,13 +682,14 @@ abstract class BaseCompiler
      * @param  string|null          $alias
      * @param  bool                 $allowAlias
      * @param  string               $sourcePath
+     * @return CompiledExpression
      */
     protected function compileModelCountDescriptor(
         ExpressionDescriptor $descriptor,
         ?string $alias,
         bool $allowAlias,
         string $sourcePath
-    ): Expression {
+    ): CompiledExpression {
         $paths = $descriptor->paths();
 
         if (count($paths) === 1) {
@@ -708,13 +725,14 @@ abstract class BaseCompiler
      * @param  string|null          $alias
      * @param  bool                 $allowAlias
      * @param  string               $sourcePath
+     * @return CompiledExpression
      */
     protected function compileMultiPathCountDescriptor(
         ExpressionDescriptor $descriptor,
         ?string $alias,
         bool $allowAlias,
         string $sourcePath
-    ): Expression {
+    ): CompiledExpression {
         if (! $descriptor->distinct()) {
             throw new \RuntimeException(
                 'Multi-path count descriptors currently require [distinct => true].'
@@ -765,13 +783,14 @@ abstract class BaseCompiler
      * @param  string|null          $alias
      * @param  bool                 $allowAlias
      * @param  string               $sourcePath
+     * @return CompiledExpression
      */
     protected function compileExistsCountDescriptor(
         ExpressionDescriptor $descriptor,
         ?string $alias,
         bool $allowAlias,
         string $sourcePath
-    ): Expression {
+    ): CompiledExpression {
         if (! $descriptor->distinct()) {
             throw new \RuntimeException(
                 'EXISTS-based count descriptors currently require [distinct => true].'
@@ -820,13 +839,14 @@ abstract class BaseCompiler
      * @param  string|null          $alias
      * @param  bool                 $allowAlias
      * @param  string               $sourcePath
+     * @return CompiledExpression
      */
     protected function compileUnionCountDescriptor(
         ExpressionDescriptor $descriptor,
         ?string $alias,
         bool $allowAlias,
         string $sourcePath
-    ): Expression {
+    ): CompiledExpression {
         if (! $descriptor->distinct()) {
             throw new \RuntimeException(
                 'Multi-path count descriptors currently require [distinct => true].'
@@ -960,11 +980,12 @@ abstract class BaseCompiler
      */
     protected function countOriginalBindings(mixed $clause): int
     {
-        if ($clause instanceof Expression) {
-            return substr_count(
-                $clause->getValue($this->builder->getGrammar()), // @phpstan-ignore-line
-                '?'
-            );
+        if ($clause instanceof ExpressionContract) {
+            $value = $clause->getValue($this->builder->getGrammar());
+
+            return is_string($value)
+                ? substr_count($value, '?')
+                : 0;
         }
 
         if (! is_array($clause)) {
@@ -984,7 +1005,9 @@ abstract class BaseCompiler
             'JsonLength',
             'Fulltext',
         ], true)) {
-            return ($clause['value'] ?? null) instanceof Expression ? 0 : 1;
+            return ($clause['value'] ?? null) instanceof ExpressionContract
+                ? 0
+                : 1;
         }
 
         $values = $clause['values'] ?? null;
@@ -1015,14 +1038,14 @@ abstract class BaseCompiler
      * @param  string|null  $alias
      * @param  bool         $allowAutoAliasing
      * @param  string|null  $relationshipPath
-     * @return Expression
+     * @return CompiledExpression
      */
     protected function resolveColumnExpression(
         string $column,
         ?string $alias = null,
         bool $allowAutoAliasing = true,
         ?string $relationshipPath = null
-    ): Expression {
+    ): CompiledExpression {
         if ($modelPath = $this->parseDescribedPathExpression($column)) {
             if ($alias !== null && empty($modelPath['alias'])) {
                 $modelPath['alias'] = $alias;
@@ -1117,13 +1140,13 @@ abstract class BaseCompiler
      *
      * @param  string       $sql
      * @param  string|null  $alias
-     * @return Expression
+     * @return CompiledExpression
      */
     protected function makeExpression(
         string $sql,
         ?string $alias = null
-    ): Expression {
-        return new Expression(
+    ): CompiledExpression {
+        return new CompiledExpression(
             $this->normalizeSqlExpression($sql, $alias)
         );
     }
@@ -1205,7 +1228,7 @@ abstract class BaseCompiler
             $column = array_pop($parts);
             $target = array_pop($parts);
 
-            if ($column === null || $column === '' || $target === null || $target === '') {
+            if ($column === '' || $target === null || $target === '') {
                 return false;
             }
 

--- a/src/Compilers/OrderByCompiler.php
+++ b/src/Compilers/OrderByCompiler.php
@@ -2,7 +2,7 @@
 
 namespace protich\AutoJoinEloquent\Compilers;
 
-use Illuminate\Database\Query\Expression;
+use protich\AutoJoinEloquent\Support\CompiledExpression;
 
 /**
  * OrderByCompiler
@@ -25,9 +25,12 @@ class OrderByCompiler extends BaseCompiler
      *
      * @param  string $column
      * @param  bool   $allowAlias Required for compatibility; ignored here.
-     * @return Expression
+     * @return CompiledExpression
      */
-    public function compileColumn(string $column, bool $allowAlias = false): Expression
+    public function compileColumn(
+        string $column,
+        bool $allowAlias = false
+    ): CompiledExpression
     {
         $alias = $this->resolveSelectionAlias($column);
 

--- a/src/Compilers/QueryCompiler.php
+++ b/src/Compilers/QueryCompiler.php
@@ -2,6 +2,7 @@
 
 namespace protich\AutoJoinEloquent\Compilers;
 
+use Illuminate\Contracts\Database\Query\Expression as ExpressionContract;
 use Illuminate\Database\Query\Builder;
 use protich\AutoJoinEloquent\AutoJoinQueryBuilder;
 
@@ -11,6 +12,8 @@ use protich\AutoJoinEloquent\AutoJoinQueryBuilder;
  * Transforms query clauses (SELECT, WHERE, HAVING, GROUP BY, ORDER BY) using their
  * respective compiler classes. Each compiler implements BaseCompiler::compileClause().
  * This class normalizes clause input and applies auto-join and expression resolution.
+ *
+ * @phpstan-consistent-constructor
  */
 class QueryCompiler
 {
@@ -57,10 +60,17 @@ class QueryCompiler
             $compiler = new $compilerClass($this->builder);
             $compiled = $compiler->compileClause($clauses);
 
-            $query->{$clauseKey} = $this->normalizeCompiledClause(
+            $normalized = $this->normalizeCompiledClause(
                 $clauseKey,
                 $compiled
             );
+
+            if ($clauseKey === 'columns') {
+                $query->columns = $this->normalizeColumns($normalized);
+                continue;
+            }
+
+            $query->{$clauseKey} = $normalized;
         }
 
         return $query;
@@ -76,6 +86,33 @@ class QueryCompiler
     protected function normalizeCompiledClause(string $clauseKey, array $clauses): array
     {
         return $clauses;
+    }
+
+    /**
+     * Validate compiled SELECT entries for Laravel's query builder.
+     *
+     * @param  array<int|string,mixed> $columns
+     * @return array<ExpressionContract|string>
+     */
+    protected function normalizeColumns(array $columns): array
+    {
+        $normalized = [];
+
+        foreach ($columns as $key => $column) {
+            if (
+                ! is_string($column)
+                && ! $column instanceof ExpressionContract
+            ) {
+                throw new \LogicException(sprintf(
+                    'Compiled SELECT clauses must be strings or query expressions; [%s] given.',
+                    get_debug_type($column)
+                ));
+            }
+
+            $normalized[$key] = $column;
+        }
+
+        return $normalized;
     }
 
     /**

--- a/src/Compilers/SelectCompiler.php
+++ b/src/Compilers/SelectCompiler.php
@@ -2,7 +2,7 @@
 
 namespace protich\AutoJoinEloquent\Compilers;
 
-use Illuminate\Database\Query\Expression;
+use protich\AutoJoinEloquent\Support\CompiledExpression;
 
 /**
  * SelectCompiler
@@ -20,9 +20,12 @@ class SelectCompiler extends BaseCompiler
      *
      * @param  string $column
      * @param  bool   $allowAlias Required for compatibility; ignored here.
-     * @return Expression
+     * @return CompiledExpression
      */
-    public function compileColumn(string $column, bool $allowAlias = false): Expression
+    public function compileColumn(
+        string $column,
+        bool $allowAlias = false
+    ): CompiledExpression
     {
         $expression = parent::compileColumn($column, true);
 
@@ -35,17 +38,20 @@ class SelectCompiler extends BaseCompiler
      * Register a compiled select expression for later alias reuse.
      *
      * @param  string      $column
-     * @param  Expression  $expression
+     * @param  CompiledExpression $expression
      * @return void
      */
-    protected function registerSelection(string $column, Expression $expression): void
+    protected function registerSelection(
+        string $column,
+        CompiledExpression $expression
+    ): void
     {
         $parsed = $this->parseColumnParts($column);
         $key    = $parsed['column'];
         $alias  = $parsed['alias'];
 
         if ($alias === null) {
-            $sql = $expression->getValue($this->builder->getGrammar()); // @phpstan-ignore-line
+            $sql = $expression->getValue($this->builder->getGrammar());
             $alias = $this->builder->parseAlias($sql);
         }
 

--- a/src/Compilers/SubqueryCompiler.php
+++ b/src/Compilers/SubqueryCompiler.php
@@ -3,10 +3,10 @@
 namespace protich\AutoJoinEloquent\Compilers;
 
 use protich\AutoJoinEloquent\AutoJoinQueryBuilder;
-use protich\AutoJoinEloquent\Compilers\SubqueryQueryCompiler;
 use protich\AutoJoinEloquent\Support\SubQueryExpression;
 use protich\AutoJoinEloquent\Support\CompiledExpression;
-use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use RuntimeException;
 
 /**
@@ -54,9 +54,8 @@ class SubqueryCompiler extends BaseCompiler
     {
         $model  = $this->outerBuilder->getBaseModel();
         $prefix = $this->outerBuilder->nextSubqueryPrefix();
-        $query  = $model->newQuery()->getQuery();
-
-        $builder = $model->newAutoJoinBuilder($query);
+        $query = $model->getConnection()->query();
+        $builder = new AutoJoinQueryBuilder($query);
 
         $builder->setModel($model);
         $builder->setBaseModel($model);
@@ -143,24 +142,17 @@ class SubqueryCompiler extends BaseCompiler
         );
         $resolvedSql = $resolved->getValue($grammar);
 
-        if (! is_string($resolvedSql)) {
-            throw new RuntimeException(sprintf(
-                'Resolved subquery path [%s] did not produce SQL.',
-                $path
-            ));
-        }
-
         $builder->select(
             new CompiledExpression($resolvedSql)
         );
 
-        $builder->whereRaw(sprintf(
+        $builder->whereRaw(new CompiledExpression(sprintf(
             '%s.%s = %s.%s',
             $grammar->wrap($innerAlias),
             $grammar->wrap($innerKey),
             $grammar->wrap($this->getOuterAlias()),
             $grammar->wrap($this->getOuterKeyName())
-        ));
+        )));
 
         $query = $builder->getQuery();
 
@@ -373,29 +365,27 @@ class SubqueryCompiler extends BaseCompiler
             false,
             $relationshipPath
         );
-        $terminal = $resolved instanceof Expression
-            ? $resolved->getValue($grammar) // @phpstan-ignore-line
-            : (string) $resolved;
+        $terminal = $resolved->getValue($grammar);
 
         $innerAlias = $builder->getBaseAlias();
         $innerKey   = $builder->getBaseModel()->getKeyName();
 
         $builder->select(new CompiledExpression('1'));
 
-        $builder->whereRaw(sprintf(
+        $builder->whereRaw(new CompiledExpression(sprintf(
             '%s.%s = %s.%s',
             $grammar->wrap($innerAlias),
             $grammar->wrap($innerKey),
             $grammar->wrap($this->getOuterAlias()),
             $grammar->wrap($this->getOuterKeyName())
-        ));
+        )));
 
-        $builder->whereRaw(sprintf(
+        $builder->whereRaw(new CompiledExpression(sprintf(
             '%s = %s.%s',
             $terminal,
             $grammar->wrap($targetAlias),
             $grammar->wrap($targetField)
-        ));
+        )));
 
         $query = $builder->getQuery();
 
@@ -418,15 +408,25 @@ class SubqueryCompiler extends BaseCompiler
      * of the final relation.
      *
      * @param  array<int, array{relation: string, join: string}> $chain
-     * @return \Illuminate\Database\Eloquent\Model
+     * @return Model
      */
-    protected function resolveExistsCountTargetModel(array $chain)
+    protected function resolveExistsCountTargetModel(array $chain): Model
     {
         $model = $this->outerBuilder->getBaseModel();
 
         foreach ($chain as $step) {
             $relation = $step['relation'];
-            $rel      = $model->{$relation}();
+            $rel = Relation::noConstraints(
+                fn () => $model->{$relation}()
+            );
+
+            if (! $rel instanceof Relation) {
+                throw new RuntimeException(sprintf(
+                    'Method [%s] on model [%s] did not return an Eloquent relationship.',
+                    $relation,
+                    $model::class
+                ));
+            }
 
             $model = $rel->getRelated();
         }
@@ -480,6 +480,15 @@ class SubqueryCompiler extends BaseCompiler
                     $path
                 ));
             }
+        }
+
+        if (
+            $targetRelation === null
+            || $targetChain === null
+        ) {
+            throw new RuntimeException(
+                'EXISTS count paths must not be empty.'
+            );
         }
 
         return [

--- a/src/Compilers/SubqueryCompiler.php
+++ b/src/Compilers/SubqueryCompiler.php
@@ -112,11 +112,14 @@ class SubqueryCompiler extends BaseCompiler
      * and correlates the inner query to the current outer row using the
      * base model key.
      *
-     * @param  string $path
+     * @param  string      $path
+     * @param  string|null $relationshipPath
      * @return \Illuminate\Database\Query\Builder
      */
-    protected function buildPathSelectSubquery(string $path)
-    {
+    protected function buildPathSelectSubquery(
+        string $path,
+        ?string $relationshipPath = null
+    ) {
         $path = trim($path);
 
         if ($path === '') {
@@ -131,7 +134,25 @@ class SubqueryCompiler extends BaseCompiler
         $innerAlias = $builder->getBaseAlias();
         $innerKey   = $builder->getBaseModel()->getKeyName();
 
-        $builder->select($path);
+        $column = $this->normalizeColumn($path);
+        $resolved = $builder->resolveColumnExpression(
+            $column,
+            null,
+            false,
+            $relationshipPath
+        );
+        $resolvedSql = $resolved->getValue($grammar);
+
+        if (! is_string($resolvedSql)) {
+            throw new RuntimeException(sprintf(
+                'Resolved subquery path [%s] did not produce SQL.',
+                $path
+            ));
+        }
+
+        $builder->select(
+            new CompiledExpression($resolvedSql)
+        );
 
         $builder->whereRaw(sprintf(
             '%s.%s = %s.%s',
@@ -157,12 +178,18 @@ class SubqueryCompiler extends BaseCompiler
      * The returned expression is wrapped and intended for use anywhere a
      * final subquery expression is required.
      *
-     * @param  string $path
+     * @param  string      $path
+     * @param  string|null $relationshipPath
      * @return SubQueryExpression
      */
-    public function compilePathSelectSubquery(string $path): SubQueryExpression
-    {
-        $subquery = $this->compilePathSelectSubquerySqlExpression($path);
+    public function compilePathSelectSubquery(
+        string $path,
+        ?string $relationshipPath = null
+    ): SubQueryExpression {
+        $subquery = $this->compilePathSelectSubquerySqlExpression(
+            $path,
+            $relationshipPath
+        );
 
         return new SubQueryExpression(sprintf(
             '(%s)',
@@ -176,25 +203,36 @@ class SubqueryCompiler extends BaseCompiler
      * The returned SQL is not wrapped in outer parentheses and is intended
      * for use in UNION composition.
      *
-     * @param  string $path
+     * @param  string      $path
+     * @param  string|null $relationshipPath
      * @return string
      */
-    public function compilePathSelectSubquerySql(string $path): string
-    {
-        return $this->compilePathSelectSubquerySqlExpression($path)
+    public function compilePathSelectSubquerySql(
+        string $path,
+        ?string $relationshipPath = null
+    ): string {
+        return $this->compilePathSelectSubquerySqlExpression(
+            $path,
+            $relationshipPath
+        )
             ->sql();
     }
 
     /**
      * Compile raw subquery SQL together with its ordered bindings.
      *
-     * @param  string  $path
+     * @param  string      $path
+     * @param  string|null $relationshipPath
      * @return SubQueryExpression
      */
     public function compilePathSelectSubquerySqlExpression(
-        string $path
+        string $path,
+        ?string $relationshipPath = null
     ): SubQueryExpression {
-        $query = $this->buildPathSelectSubquery($path);
+        $query = $this->buildPathSelectSubquery(
+            $path,
+            $relationshipPath
+        );
 
         return new SubQueryExpression(
             $query->toSql(),
@@ -222,24 +260,31 @@ class SubqueryCompiler extends BaseCompiler
      *   )
      *
      * @param  array<int,string> $paths
+     * @param  string|null       $relationshipPath
      * @return string
      */
-    public function compileExistsCountSubquerySql(array $paths): string
-    {
-        return $this->compileExistsCountSubquery($paths)
+    public function compileExistsCountSubquerySql(
+        array $paths,
+        ?string $relationshipPath = null
+    ): string {
+        return $this->compileExistsCountSubquery(
+            $paths,
+            $relationshipPath
+        )
             ->sql();
     }
 
     /**
      * Compile a binding-aware target-anchored EXISTS count subquery.
      *
-     * @param  array<int,string>  $paths
+     * @param  array<int,string> $paths
+     * @param  string|null       $relationshipPath
      * @return SubQueryExpression
      */
     public function compileExistsCountSubquery(
-        array $paths
-    ): SubQueryExpression
-    {
+        array $paths,
+        ?string $relationshipPath = null
+    ): SubQueryExpression {
         if ($paths === []) {
             throw new RuntimeException(
                 'EXISTS count subquery requires at least one path.'
@@ -255,7 +300,8 @@ class SubqueryCompiler extends BaseCompiler
             fn (string $path) => $this->compilePathExistsPredicateSql(
                 $path,
                 $alias,
-                $target['field']
+                $target['field'],
+                $relationshipPath
             ),
             $paths
         );
@@ -297,15 +343,17 @@ class SubqueryCompiler extends BaseCompiler
      *       and terminal_value = target_alias.target_field
      *   )
      *
-     * @param  string $path
-     * @param  string $targetAlias
-     * @param  string $targetField
+     * @param  string      $path
+     * @param  string      $targetAlias
+     * @param  string      $targetField
+     * @param  string|null $relationshipPath
      * @return SubQueryExpression
      */
     protected function compilePathExistsPredicateSql(
         string $path,
         string $targetAlias,
-        string $targetField
+        string $targetField,
+        ?string $relationshipPath = null
     ): SubQueryExpression {
         $path = trim($path);
 
@@ -319,7 +367,12 @@ class SubqueryCompiler extends BaseCompiler
         $grammar = $builder->getGrammar();
 
         $column = $this->normalizeColumn($path);
-        $resolved = $builder->resolveColumnExpression($column, null, false);
+        $resolved = $builder->resolveColumnExpression(
+            $column,
+            null,
+            false,
+            $relationshipPath
+        );
         $terminal = $resolved instanceof Expression
             ? $resolved->getValue($grammar) // @phpstan-ignore-line
             : (string) $resolved;

--- a/src/Compilers/SubqueryQueryCompiler.php
+++ b/src/Compilers/SubqueryQueryCompiler.php
@@ -46,9 +46,11 @@ class SubqueryQueryCompiler extends QueryCompiler
             }
 
             if ($clause instanceof Expression) {
-                return new CompiledExpression(
-                    $clause->getValue($this->builder->getGrammar()) // @phpstan-ignore-line
-                );
+                $value = $clause->getValue($this->builder->getGrammar());
+
+                return is_string($value)
+                    ? new CompiledExpression($value)
+                    : $clause;
             }
 
             if (is_array($clause) && isset($clause['column'])) {
@@ -59,9 +61,13 @@ class SubqueryQueryCompiler extends QueryCompiler
                 }
 
                 if ($column instanceof Expression) {
-                    $clause['column'] = new CompiledExpression(
-                        $column->getValue($this->builder->getGrammar()) // @phpstan-ignore-line
+                    $value = $column->getValue(
+                        $this->builder->getGrammar()
                     );
+
+                    if (is_string($value)) {
+                        $clause['column'] = new CompiledExpression($value);
+                    }
                 }
 
                 return $clause;

--- a/src/Compilers/WhereCompiler.php
+++ b/src/Compilers/WhereCompiler.php
@@ -33,12 +33,16 @@ class WhereCompiler extends BaseCompiler
      */
     public function compileColumn(string $column, bool $allowAlias = false): Expression
     {
+        if ($modelPath = $this->parseDescribedPathExpression($column)) {
+            return $this->compileModelDefinedPath($modelPath, false);
+        }
+
         if ($this->parseAggregateExpression($column)) {
             throw new Exception("Aggregate expressions are not allowed in WHERE clauses.");
         }
 
         // Aliasing not allowed — pass false explicitly
-        return parent::compileColumn($column, false);
+        return $this->compileStandardColumn($column, false);
     }
 
     /**

--- a/src/Compilers/WhereCompiler.php
+++ b/src/Compilers/WhereCompiler.php
@@ -3,7 +3,7 @@
 namespace protich\AutoJoinEloquent\Compilers;
 
 use Illuminate\Database\Query\Builder;
-use Illuminate\Database\Query\Expression;
+use protich\AutoJoinEloquent\Support\CompiledExpression;
 use Exception;
 
 /**
@@ -28,10 +28,13 @@ class WhereCompiler extends BaseCompiler
      *
      * @param string $column The raw column expression.
      * @param bool $allowAlias Required by interface; always ignored (false).
-     * @return Expression The compiled expression.
+     * @return CompiledExpression The compiled expression.
      * @throws Exception If an aggregate expression is detected in WHERE clause.
      */
-    public function compileColumn(string $column, bool $allowAlias = false): Expression
+    public function compileColumn(
+        string $column,
+        bool $allowAlias = false
+    ): CompiledExpression
     {
         if ($modelPath = $this->parseDescribedPathExpression($column)) {
             return $this->compileModelDefinedPath($modelPath, false);
@@ -50,10 +53,9 @@ class WhereCompiler extends BaseCompiler
      *
      * Recursively compiles nested where groups (type = "Nested") using a fresh WhereCompiler instance.
      *
-     * @param array $wheres
-     * @return array
+     * @param array<int|string,mixed> $wheres
+     * @return array<int|string,mixed>
      */
-    // @phpstan-ignore-next-line
     public function compileClause(array $wheres): array
     {
         $compiled = [];
@@ -80,8 +82,11 @@ class WhereCompiler extends BaseCompiler
                     $where['column'] = $this->compileColumn( $where['column']);
                 }
 
-                if (isset($where['sql']) && is_string($where['sql'])
-                    && strcasecmp( $where['type'] ?? '', 'Raw') === 0) { // @phpstan-ignore-line
+                if (
+                    is_string($where['sql'] ?? null)
+                    && is_string($where['type'] ?? null)
+                    && strcasecmp($where['type'], 'Raw') === 0
+                ) {
                     $where['sql'] = $this->compileRawSql( $where['sql']);
                 }
             }

--- a/src/Join/JoinAliasManager.php
+++ b/src/Join/JoinAliasManager.php
@@ -89,8 +89,13 @@ class JoinAliasManager
         return $this->aliasPrefix;
     }
 
-
-    public function getAliasMap() {
+    /**
+     * Get the resolved alias map.
+     *
+     * @return array<string,string>
+     */
+    public function getAliasMap(): array
+    {
         return $this->aliasMap;
     }
 
@@ -177,13 +182,23 @@ class JoinAliasManager
      */
     public function resolveModelAlias(Model $model, string $chainKey, ?string $default = null): string
     {
-        if (property_exists($model, 'joinAliases') 
-            && isset($model->joinAliases[$chainKey]) // @phpstan-ignore-line
-            && ($customAlias = $model->joinAliases[$chainKey])
-            && !in_array($customAlias, $this->aliasMap, true)) {
-            /** @var string $customAlias */
+        if (! property_exists($model, 'joinAliases')) {
+            return $this->getAlias($chainKey, $default);
+        }
+
+        $aliases = $model->joinAliases;
+        $customAlias = is_array($aliases)
+            ? ($aliases[$chainKey] ?? null)
+            : null;
+
+        if (
+            is_string($customAlias)
+            && $customAlias !== ''
+            && ! in_array($customAlias, $this->aliasMap, true)
+        ) {
             $this->setAlias($chainKey, $customAlias);
         }
+
         return $this->getAlias($chainKey, $default);
     }
 }

--- a/src/Join/JoinAliasManager.php
+++ b/src/Join/JoinAliasManager.php
@@ -101,7 +101,9 @@ class JoinAliasManager
      * If not, it generates a new alias. When simple alias generation is enabled,
      * it uses sequential aliases (A, B, C, …, then A1, B1, etc.), ensuring no duplicates.
      * Otherwise, it uses the provided default or falls back to the key itself.
-     * The resolved alias is stored in the alias map and returned.
+     * If that alias is already assigned, the relationship key and then a
+     * numeric suffix are used to keep aliases unique. The resolved alias is
+     * stored in the alias map and returned.
      *
      * @param string      $key     The mapping key (e.g. a relationship chain or table name).
      * @param string|null $default Optional default alias if none is set.
@@ -126,7 +128,20 @@ class JoinAliasManager
 
                 $this->aliasMap[$key] = $alias;
             } else {
-                $this->aliasMap[$key] = $default ?? $key;
+                $alias = $default ?? $key;
+
+                if (in_array($alias, $this->aliasMap, true)) {
+                    $alias = $key;
+                }
+
+                $suffix = 2;
+                $candidate = $alias;
+
+                while (in_array($candidate, $this->aliasMap, true)) {
+                    $candidate = sprintf('%s_%d', $alias, $suffix++);
+                }
+
+                $this->aliasMap[$key] = $candidate;
             }
         }
 

--- a/src/Join/JoinClauseInfo.php
+++ b/src/Join/JoinClauseInfo.php
@@ -8,17 +8,18 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Database\Query\Expression;
+use Illuminate\Contracts\Database\Query\Expression;
 use Illuminate\Database\Query\Grammars\Grammar;
 
 use protich\AutoJoinEloquent\Model\AutoJoinRelation;
+use protich\AutoJoinEloquent\Support\CompiledExpression;
 
 class JoinClauseInfo
 {
     /**
      * The Eloquent relationship instance.
      *
-     * @var \Illuminate\Database\Eloquent\Relations\Relation
+     * @var Relation<covariant Model,covariant Model,covariant mixed>
      */
     protected Relation $relation;
 
@@ -32,7 +33,7 @@ class JoinClauseInfo
     /**
      * Create a new JoinClauseInfo instance.
      *
-     * @param  \Illuminate\Database\Eloquent\Relations\Relation  $relation
+     * @param Relation<covariant Model,covariant Model,covariant mixed> $relation
      * @param  string  $joinType  The join type to use (defaults to 'left').
      *
      * @throws \InvalidArgumentException If the relationship type is unsupported.
@@ -210,7 +211,10 @@ class JoinClauseInfo
      * @param \Illuminate\Database\Query\Grammars\Grammar $grammar   The query grammar instance.
      * @param string                                      $baseAlias The alias for the base model's table.
      * @param string                                      $joinAlias The alias for the joined (related) table.
-     * @return array{foreign: Expression, owner: Expression}
+     * @return array{
+     *     foreign: Expression,
+     *     owner: Expression
+     * }
      *
      * @throws \Exception If the relationship is an instance of BelongsToMany or if key formats are invalid.
      */
@@ -233,18 +237,18 @@ class JoinClauseInfo
         $ownerColumn   = end($ownerParts);
         if ($this->relation instanceof BelongsTo) {
             // For belongsTo, the base model holds the foreign key.
-            $foreignExpr = new Expression(
+            $foreignExpr = new CompiledExpression(
                 sprintf('%s.%s', $grammar->wrap($baseAlias), $grammar->wrap($foreignColumn))
             );
-            $ownerExpr = new Expression(
+            $ownerExpr = new CompiledExpression(
                 sprintf('%s.%s', $grammar->wrap($joinAlias), $grammar->wrap($ownerColumn))
             );
         } else {
             // For hasOne/hasMany, the joined (related) model holds the foreign key.
-            $foreignExpr = new Expression(
+            $foreignExpr = new CompiledExpression(
                 sprintf('%s.%s', $grammar->wrap($joinAlias), $grammar->wrap($foreignColumn))
             );
-            $ownerExpr = new Expression(
+            $ownerExpr = new CompiledExpression(
                 sprintf('%s.%s', $grammar->wrap($baseAlias), $grammar->wrap($ownerColumn))
             );
         }
@@ -264,7 +268,10 @@ class JoinClauseInfo
      * @param Grammar $grammar   The query grammar instance.
      * @param string  $baseAlias The alias for the base model's table.
      * @param string  $pivotAlias The alias for the pivot table.
-     * @return array{base: Expression, pivot: Expression}
+     * @return array{
+     *     base: Expression,
+     *     pivot: Expression
+     * }
      *
      * @throws \Exception If the foreign pivot key format is invalid.
      */
@@ -281,10 +288,10 @@ class JoinClauseInfo
         }
         $field = end($parts);
 
-        $baseExpr = new Expression(
+        $baseExpr = new CompiledExpression(
             sprintf('%s.%s', $grammar->wrap($baseAlias), $grammar->wrap($baseKey))
         );
-        $pivotExpr = new Expression(
+        $pivotExpr = new CompiledExpression(
             sprintf('%s.%s', $grammar->wrap($pivotAlias), $grammar->wrap($field))
         );
 
@@ -304,7 +311,10 @@ class JoinClauseInfo
      * @param Grammar $grammar     The query grammar instance.
      * @param string  $pivotAlias  The alias for the pivot table.
      * @param string  $relatedAlias The alias for the related model's table.
-     * @return array{pivot: Expression, related: Expression}
+     * @return array{
+     *     pivot: Expression,
+     *     related: Expression
+     * }
      *
      * @throws \Exception If the related pivot key format is invalid.
      */
@@ -321,10 +331,10 @@ class JoinClauseInfo
         // Retrieve the primary key from the related model.
         $relatedKey = $this->relation->getRelated()->getKeyName();
 
-        $pivotExpr = new Expression(
+        $pivotExpr = new CompiledExpression(
             sprintf('%s.%s', $grammar->wrap($pivotAlias), $grammar->wrap($field))
         );
-        $relatedExpr = new Expression(
+        $relatedExpr = new CompiledExpression(
             sprintf('%s.%s', $grammar->wrap($relatedAlias), $grammar->wrap($relatedKey))
         );
 
@@ -355,7 +365,7 @@ class JoinClauseInfo
     /**
      * Create a new JoinClauseInfo instance from a relationship.
      *
-     * @param \Illuminate\Database\Eloquent\Relations\Relation $relation
+     * @param Relation<covariant Model,covariant Model,covariant mixed> $relation
      * @param string $joinType  The join type to use (defaults to 'left').
      * @return self
      *
@@ -373,7 +383,8 @@ class JoinClauseInfo
      * and then uses it to construct a JoinContext value object that encapsulates the join details,
      * the cumulative chain key, the current (base) model, and its current alias.
      *
-     * @param Relation $relation The Eloquent relationship instance.
+     * @param Relation<covariant Model,covariant Model,covariant mixed> $relation
+     *        The Eloquent relationship instance.
      * @param string   $chainKey The cumulative join key for the relationship chain.
      * @param Model    $currentModel The current base model instance.
      * @param string   $currentAlias The current alias for the base table.
@@ -408,7 +419,7 @@ class JoinClauseInfo
     /**
      * Build the exception used for an unsupported Eloquent relationship.
      *
-     * @param  Relation  $relation
+     * @param Relation<covariant Model,covariant Model,covariant mixed> $relation
      * @return \InvalidArgumentException
      */
     private static function unsupportedRelationship(

--- a/src/Model/PathRequest.php
+++ b/src/Model/PathRequest.php
@@ -7,23 +7,23 @@ use InvalidArgumentException;
 /**
  * Class: PathRequest
  *
- * The complete model-defined path submitted to a model hook.
+ * The complete unresolved path remainder submitted to a model hook.
  *
- * The path is deliberately kept intact so the auto-joiner does not interpret
- * application-defined segments. The auto-joiner removes its reserved marker
- * before constructing the request.
+ * Normal relationship hops are resolved before the request is constructed.
+ * The remaining model-owned expression is kept intact so the package does not
+ * impose application-specific segmentation rules.
  */
 final readonly class PathRequest
 {
     /**
-     * Complete application-defined path without the auto-join marker.
+     * Complete model-local remainder without the auto-join marker.
      *
      * @var non-empty-string
      */
     public string $path;
 
     /**
-     * Create a request for a complete model-defined path.
+     * Create a request for a complete unresolved path remainder.
      *
      * @param  string  $path
      *

--- a/src/Model/PathRequest.php
+++ b/src/Model/PathRequest.php
@@ -10,13 +10,13 @@ use InvalidArgumentException;
  * The complete model-defined path submitted to a model hook.
  *
  * The path is deliberately kept intact so the auto-joiner does not interpret
- * application-defined segments. Models receive the reserved `model__` marker
- * and decide how the complete expression should be described.
+ * application-defined segments. The auto-joiner removes its reserved marker
+ * before constructing the request.
  */
 final readonly class PathRequest
 {
     /**
-     * Complete model-defined path, including the `model__` marker.
+     * Complete application-defined path without the auto-join marker.
      *
      * @var non-empty-string
      */
@@ -27,18 +27,16 @@ final readonly class PathRequest
      *
      * @param  string  $path
      *
-     * @throws InvalidArgumentException If the path does not contain a name
-     *                                  after the `model__` marker.
+     * @throws InvalidArgumentException If the path is empty.
      */
     public function __construct(string $path)
     {
         $path = trim($path);
 
-        if (! str_starts_with($path, 'model__') || $path === 'model__') {
-            throw new InvalidArgumentException(sprintf(
-                'Auto-join model path [%s] must begin with [model__].',
-                $path
-            ));
+        if ($path === '') {
+            throw new InvalidArgumentException(
+                'Auto-join model path must not be empty.'
+            );
         }
 
         $this->path = $path;

--- a/src/Support/CompiledExpression.php
+++ b/src/Support/CompiledExpression.php
@@ -2,7 +2,8 @@
 
 namespace protich\AutoJoinEloquent\Support;
 
-use Illuminate\Database\Query\Expression;
+use Illuminate\Contracts\Database\Query\Expression;
+use Illuminate\Database\Grammar;
 
 /**
  * Class: CompiledExpression
@@ -13,8 +14,13 @@ use Illuminate\Database\Query\Expression;
  * Expression instances, which may still need to pass through the
  * auto-join compiler pipeline.
  */
-class CompiledExpression extends Expression
+class CompiledExpression implements Expression
 {
+    /**
+     * Compiler-generated SQL.
+     */
+    private string $compiledValue;
+
     /**
      * Create a new compiled expression.
      *
@@ -23,6 +29,17 @@ class CompiledExpression extends Expression
      */
     public function __construct(string $value)
     {
-        parent::__construct($value);
+        $this->compiledValue = $value;
+    }
+
+    /**
+     * Get the compiler-generated SQL.
+     *
+     * @param  Grammar $grammar
+     * @return string
+     */
+    public function getValue(Grammar $grammar): string
+    {
+        return $this->compiledValue;
     }
 }

--- a/src/Traits/AutoJoinQueryBuilderTrait.php
+++ b/src/Traits/AutoJoinQueryBuilderTrait.php
@@ -3,6 +3,7 @@
 namespace protich\AutoJoinEloquent\Traits;
 
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 use protich\AutoJoinEloquent\AutoJoinQueryBuilder;
 use protich\AutoJoinEloquent\Model\AutoJoinRelation;
 use protich\AutoJoinEloquent\Model\ExpressionDescriptor;
@@ -108,7 +109,7 @@ trait AutoJoinQueryBuilderTrait
      * @return AutoJoinQueryBuilder
      */
     protected function newAutoJoinQueryBuilder(
-        $query,
+        QueryBuilder $query,
         string $joinType = 'left'
     ): AutoJoinQueryBuilder {
         $builder = new AutoJoinQueryBuilder($query);
@@ -137,12 +138,12 @@ trait AutoJoinQueryBuilderTrait
      * @return AutoJoinQueryBuilder
      */
     public function newAutoJoinBuilder(
-        $query,
+        QueryBuilder $query,
         string $joinType = 'left'
     ): AutoJoinQueryBuilder {
         $builder = $this->newAutoJoinQueryBuilder($query, $joinType);
 
-        $query->beforeQuery(function ($query) use ($builder) {
+        $query->beforeQuery(function (QueryBuilder $query) use ($builder) {
             $builder->autoJoinQuery($query);
         });
 

--- a/src/Traits/AutoJoinQueryBuilderTrait.php
+++ b/src/Traits/AutoJoinQueryBuilderTrait.php
@@ -19,11 +19,12 @@ use Throwable;
 trait AutoJoinQueryBuilderTrait
 {
     /**
-     * Describe a complete path carrying the reserved `model__` marker.
+     * Describe a complete application-defined path.
      *
      * Models override this hook only when they expose model-defined paths. The
-     * request contains the complete expression so the package does not impose
-     * application-specific segmentation rules.
+     * request contains the complete expression without the auto-joiner's
+     * reserved marker, so the package does not impose application-specific
+     * segmentation rules.
      *
      * @param  PathRequest  $request
      * @return ExpressionDescriptor
@@ -50,7 +51,8 @@ trait AutoJoinQueryBuilderTrait
      * implementation.
      *
      * @param  string  $name Relationship method name.
-     * @param  string  $path Complete normalized path that triggered the join.
+     * @param  string  $path Complete path that triggered the join. Model-defined
+     *                      paths do not include the reserved marker.
      * @return AutoJoinRelation Authoritative relationship description.
      *
      * @throws RuntimeException When the relationship cannot be resolved or

--- a/src/Traits/AutoJoinQueryBuilderTrait.php
+++ b/src/Traits/AutoJoinQueryBuilderTrait.php
@@ -19,26 +19,20 @@ use Throwable;
 trait AutoJoinQueryBuilderTrait
 {
     /**
-     * Describe a complete application-defined path.
+     * Describe a complete unresolved application-defined path.
      *
      * Models override this hook only when they expose model-defined paths. The
-     * request contains the complete expression without the auto-joiner's
-     * reserved marker, so the package does not impose application-specific
-     * segmentation rules.
+     * request contains the intact model-local remainder without the reserved
+     * marker. Returning null declines the expression and preserves normal
+     * compiler behavior.
      *
      * @param  PathRequest  $request
-     * @return ExpressionDescriptor
-     *
-     * @throws RuntimeException When the model does not support the path.
+     * @return ExpressionDescriptor|null
      */
     public static function describeAutoJoinPath(
         PathRequest $request
-    ): ExpressionDescriptor {
-        throw new RuntimeException(sprintf(
-            'Model [%s] does not support auto-join path [%s].',
-            static::class,
-            $request->path
-        ));
+    ): ?ExpressionDescriptor {
+        return null;
     }
 
     /**
@@ -51,8 +45,8 @@ trait AutoJoinQueryBuilderTrait
      * implementation.
      *
      * @param  string  $name Relationship method name.
-     * @param  string  $path Complete path that triggered the join. Model-defined
-     *                      paths do not include the reserved marker.
+     * @param  string  $path Expression path that triggered the join. Model-
+     *                      defined paths do not include the reserved marker.
      * @return AutoJoinRelation Authoritative relationship description.
      *
      * @throws RuntimeException When the relationship cannot be resolved or

--- a/src/Traits/AutoJoinTrait.php
+++ b/src/Traits/AutoJoinTrait.php
@@ -20,7 +20,9 @@ trait AutoJoinTrait
      * @param  \Illuminate\Database\Query\Builder $query
      * @return AutoJoinQueryBuilder
      */
-    public function newEloquentBuilder($query): AutoJoinQueryBuilder
+    public function newEloquentBuilder(
+        $query
+    ): AutoJoinQueryBuilder
     {
         return $this->newAutoJoinBuilder($query);
     }

--- a/src/Traits/QueryJoinerTrait.php
+++ b/src/Traits/QueryJoinerTrait.php
@@ -2,7 +2,8 @@
 
 namespace protich\AutoJoinEloquent\Traits;
 
-use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 
 /**
  * Trait: QueryJoinerTrait
@@ -18,18 +19,23 @@ trait QueryJoinerTrait
     /**
      * Scope a query to manually trigger auto join logic.
      *
-     * @param  \Illuminate\Database\Eloquent\Builder $query
-     * @param  string                                $joinType
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @template TModel of Model
+     * @param  Builder<TModel> $query
+     * @param  string          $joinType
+     * @return Builder<TModel>
      */
-    public function scopeWithAutoJoins($query, string $joinType = 'left')
-    {
+    public function scopeWithAutoJoins(
+        Builder $query,
+        string $joinType = 'left'
+    ): Builder {
         $model = $query->getModel();
 
-        $builder = $model->newAutoJoinBuilder($query->getQuery(), $joinType);
+        $builder = $this->newAutoJoinBuilder(
+            $query->getQuery(),
+            $joinType
+        );
         $builder->setBaseModel($model);
 
         return $query;
     }
-
 }

--- a/tests/AutoJoinTestCase.php
+++ b/tests/AutoJoinTestCase.php
@@ -109,7 +109,15 @@ abstract class AutoJoinTestCase extends TestCase
         // If schema is not set, get it from the environment variable (AUTO_JOIN_TEST_SCHEMA)
         // or default to "default".
         if ($this->schema === null) {
-            $this->schema = env('AUTO_JOIN_TEST_SCHEMA', 'default'); // @phpstan-ignore-line
+            $schema = env('AUTO_JOIN_TEST_SCHEMA', 'default');
+
+            if (! is_string($schema)) {
+                throw new \UnexpectedValueException(
+                    'AUTO_JOIN_TEST_SCHEMA must be a string.'
+                );
+            }
+
+            $this->schema = $schema;
         }
 
         // Configure the in‑memory SQLite database.
@@ -216,7 +224,9 @@ abstract class AutoJoinTestCase extends TestCase
         foreach ($results as $row) {
             $row = is_object($row) ? get_object_vars($row) : (array)$row;
             foreach ($headers as $header) {
-                $value = array_key_exists($header, $row) ? (string)$row[$header] : ''; // @phpstan-ignore-line
+                $value = array_key_exists($header, $row)
+                    ? $this->formatDebugValue($row[$header])
+                    : '';
                 $widths[$header] = max($widths[$header], strlen($value));
             }
         }
@@ -246,12 +256,39 @@ abstract class AutoJoinTestCase extends TestCase
             $row = is_object($row) ? get_object_vars($row) : (array)$row;
             $rowLine = '|';
             foreach ($headers as $header) {
-                $value = array_key_exists($header, $row) ? (string)$row[$header] : ''; // @phpstan-ignore-line
+                $value = array_key_exists($header, $row)
+                    ? $this->formatDebugValue($row[$header])
+                    : '';
                 $rowLine .= ' ' . str_pad($value, $widths[$header], ' ', STR_PAD_RIGHT) . ' |';
             }
             echo $rowLine . "\n";
         }
         echo $line . "\n";
+    }
+
+    /**
+     * Format a value for debug table output.
+     *
+     * @param  mixed $value
+     * @return string
+     */
+    private function formatDebugValue(mixed $value): string
+    {
+        if ($value === null) {
+            return '';
+        }
+
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        if (is_scalar($value) || $value instanceof \Stringable) {
+            return (string) $value;
+        }
+
+        $encoded = json_encode($value);
+
+        return $encoded === false ? '' : $encoded;
     }
 
     /**
@@ -273,7 +310,6 @@ abstract class AutoJoinTestCase extends TestCase
     {
         if (is_string($source)) {
             // Fetch results from the specified table.
-             /** @phpstan-ignore-next-line */
             $results = array_map('get_object_vars', $this->db->table($source)->get()->all());
             $title = $title ?: $source;
         } else {
@@ -302,7 +338,7 @@ abstract class AutoJoinTestCase extends TestCase
     protected function assertTablesNonEmpty(?array $tables = null): void
     {
         $tables = $tables ?? $this->seeder->getTables();
-        $this->assertIsArray($tables, 'Tables should be an array.'); // @phpstan-ignore-line
+
         foreach ($tables as $table) {
             /** @var string $table */
             $this->assertNonEmptyResults($table, $table);
@@ -315,7 +351,9 @@ abstract class AutoJoinTestCase extends TestCase
      * This method outputs the compiled SQL query in green if either the global debug flag
      * or the forcedDebug parameter is true, then returns the SQL string.
      *
-     * @param \Illuminate\Database\Query\Builder $query       The query builder instance.
+     * @param \Illuminate\Database\Query\Builder
+     *     |\Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model> $query
+     *     The query builder instance.
      * @param bool                                 $forcedDebug Optional flag to force debug output regardless of the global debug flag (default false).
      * @return string The compiled SQL query.
      */

--- a/tests/Integration/QueryJoinerIntegrationTest.php
+++ b/tests/Integration/QueryJoinerIntegrationTest.php
@@ -7,6 +7,8 @@ use protich\AutoJoinEloquent\Traits\QueryJoinerTrait;
 
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 
 
 // Inline Model class that doesn't use AutoJoinTrait
@@ -19,9 +21,9 @@ class User extends Model
 
     /**
      * Summary of agent
-     * @return \Illuminate\Database\Eloquent\Relations\HasOne
+     * @return HasOne<Agent,$this>
      */
-    public function agent()
+    public function agent(): HasOne
     {
         return $this->hasOne(Agent::class);
     }
@@ -36,9 +38,9 @@ class Agent extends Model
 
     /**
      * Summary of user
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     * @return BelongsTo<User,$this>
      */
-    public function user()
+    public function user(): BelongsTo
     {
         return $this->belongsTo(User::class, 'user_id');
     }
@@ -64,18 +66,17 @@ class QueryJoinerIntegrationTest extends AutoJoinTestCase
     {
 
         // Build a query using auto-join notation.
-        /** @phpstan-ignore-next-line */
-        $query = User::query()->select([
-            'name as agent',
-            'email',
-            'agent|inner.id as agent_id',  // Use INNER JOIN for the agent relationship.
-            'agent.position',
-        ])->withAutoJoins();
+        $model = new User();
+        $query = $model
+            ->scopeWithAutoJoins(User::query())
+            ->select([
+                'name as agent',
+                'email',
+                'agent|inner.id as agent_id',
+                'agent.position',
+            ]);
 
         // Retrieve the final SQL using debugSql() for inspection.
-        /**
-         * @var \Illuminate\Database\Query\Builder $query
-         */
         $sql = $this->debugSql($query);
         $this->assertStringContainsStringIgnoringCase('INNER JOIN', $sql, 'The query should include an INNER JOIN for the agent relationship.');
         $this->assertStringContainsStringIgnoringCase('JOIN', $sql, 'The query should include JOIN clauses for nested relationships.');

--- a/tests/Models/Agent.php
+++ b/tests/Models/Agent.php
@@ -37,6 +37,16 @@ class Agent extends BaseModel
     public static array $autoJoinRelationDescriptions = [];
 
     /**
+     * Get calls made to the complex relationship description hook.
+     *
+     * @return list<array{name:string,path:string}>
+     */
+    public static function autoJoinRelationDescriptions(): array
+    {
+        return self::$autoJoinRelationDescriptions;
+    }
+
+    /**
      * Table name.
      *
      * @var string
@@ -205,8 +215,10 @@ class Agent extends BaseModel
      */
     public function userWithoutPhone(): BelongsTo
     {
-        return $this->belongsTo(User::class, 'user_id')
-            ->whereNull('users.phone');
+        $relation = $this->belongsTo(User::class, 'user_id');
+        $relation->whereNull('users.phone');
+
+        return $relation;
     }
 
     /**
@@ -216,8 +228,10 @@ class Agent extends BaseModel
      */
     public function userWithPhone(): BelongsTo
     {
-        return $this->belongsTo(User::class, 'user_id')
-            ->whereNotNull('users.phone');
+        $relation = $this->belongsTo(User::class, 'user_id');
+        $relation->whereNotNull('users.phone');
+
+        return $relation;
     }
 
     /**
@@ -227,8 +241,10 @@ class Agent extends BaseModel
      */
     public function invalidPivotUser(): BelongsTo
     {
-        return $this->belongsTo(User::class, 'user_id')
-            ->where('users.name', 'Alice');
+        $relation = $this->belongsTo(User::class, 'user_id');
+        $relation->where('users.name', 'Alice');
+
+        return $relation;
     }
 
     /**
@@ -285,20 +301,23 @@ class Agent extends BaseModel
      */
     public function qualifiedDepartments(): BelongsToMany
     {
-        return $this->belongsToMany(
+        $relation = $this->belongsToMany(
             Department::class,
             'agent_department',
             'agent_id',
             'department_id'
-        )->where('departments.name', 'Support');
+        );
+        $relation->where('departments.name', 'Support');
+
+        return $relation;
     }
 
     /**
      * An agent belongs to a user.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     * @return BelongsTo<User,$this>
      */
-    public function user()
+    public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
     }
@@ -306,9 +325,14 @@ class Agent extends BaseModel
     /**
      * Direct departments the agent belongs to.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     * @return BelongsToMany<
+     *     Department,
+     *     $this,
+     *     \Illuminate\Database\Eloquent\Relations\Pivot,
+     *     'pivot'
+     * >
      */
-    public function departments()
+    public function departments(): BelongsToMany
     {
         return $this->belongsToMany(
             Department::class,
@@ -323,9 +347,14 @@ class Agent extends BaseModel
      *
      * These provide indirect department access.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     * @return BelongsToMany<
+     *     Group,
+     *     $this,
+     *     \Illuminate\Database\Eloquent\Relations\Pivot,
+     *     'pivot'
+     * >
      */
-    public function groups()
+    public function groups(): BelongsToMany
     {
         return $this->belongsToMany(
             Group::class,

--- a/tests/Models/Agent.php
+++ b/tests/Models/Agent.php
@@ -55,8 +55,7 @@ class Agent extends BaseModel
     /**
      * Describe a model-defined auto-join path.
      *
-     * This acts as the entry point for resolving `model__*` paths
-     * into descriptor definitions understood by the auto-join compiler.
+     * The auto-joiner removes its marker before delegating the complete path.
      *
      * @param  PathRequest  $request
      * @return ExpressionDescriptor
@@ -67,22 +66,29 @@ class Agent extends BaseModel
         PathRequest $request
     ): ExpressionDescriptor {
         return match ($request->path) {
-            'model__status' => ExpressionDescriptor::path('flags'),
-            'model__accessibleDepartments__id__count' => ExpressionDescriptor::count(
+            'status' => ExpressionDescriptor::path('flags'),
+            'userNamed__Alice',
+            'userNamed__Bob' => ExpressionDescriptor::path(
+                'userByName.name'
+            ),
+            'userNamed__Alice__count' => ExpressionDescriptor::count(
+                'userByName.id'
+            ),
+            'accessibleDepartments__id__count' => ExpressionDescriptor::count(
                 [
                     'departments.id',
                     'groups.departments.id',
                 ],
                 distinct: true
             ),
-            'model__qualifiedDepartmentCount' => ExpressionDescriptor::count(
+            'qualifiedDepartmentCount' => ExpressionDescriptor::count(
                 [
                     'qualifiedDepartments.id',
                     'groups.qualifiedDepartments.id',
                 ],
                 distinct: true
             ),
-            'model__mixedComplexCount' => ExpressionDescriptor::count(
+            'mixedComplexCount' => ExpressionDescriptor::count(
                 [
                     'assignedDepartments.id',
                     'departments.id',
@@ -131,8 +137,25 @@ class Agent extends BaseModel
                 ->wherePivotNull('assigned_at'),
             'qualifiedDepartments' => $description
                 ->whereRelated('name', 'Support'),
+            'userByName' => str_starts_with(
+                $path,
+                'userNamed__'
+            ) ? $description->whereRelated(
+                'name',
+                explode('__', $path)[1] ?? ''
+            ) : $description,
             default => $description,
         };
+    }
+
+    /**
+     * Get the agent's user for a model-defined name constraint.
+     *
+     * @return BelongsTo<User, $this>
+     */
+    public function userByName(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'user_id');
     }
 
     /**

--- a/tests/Models/Agent.php
+++ b/tests/Models/Agent.php
@@ -22,8 +22,10 @@ use protich\AutoJoinEloquent\Model\PathRequest;
  * It also defines model-level auto-join paths used by the DSL,
  * such as:
  *
- * - model__status
- * - model__accessibleDepartments
+ * - status
+ * - accessibleDepartments
+ *
+ * The optional `model__` marker remains supported for explicit delegation.
  */
 class Agent extends BaseModel
 {
@@ -58,15 +60,17 @@ class Agent extends BaseModel
      * The auto-joiner removes its marker before delegating the complete path.
      *
      * @param  PathRequest  $request
-     * @return ExpressionDescriptor
-     *
-     * @throws \RuntimeException If the test path is unsupported.
+     * @return ExpressionDescriptor|null
      */
     public static function describeAutoJoinPath(
         PathRequest $request
-    ): ExpressionDescriptor {
+    ): ?ExpressionDescriptor {
         return match ($request->path) {
             'status' => ExpressionDescriptor::path('flags'),
+            'statusAlias' => ExpressionDescriptor::path('status'),
+            'circularExpression' => ExpressionDescriptor::path(
+                'circularExpression'
+            ),
             'userNamed__Alice',
             'userNamed__Bob' => ExpressionDescriptor::path(
                 'userByName.name'
@@ -95,10 +99,7 @@ class Agent extends BaseModel
                 ],
                 distinct: true
             ),
-            default => throw new \RuntimeException(sprintf(
-                'Unsupported test model path [%s].',
-                $request->path
-            )),
+            default => parent::describeAutoJoinPath($request),
         };
     }
 

--- a/tests/Models/BaseModel.php
+++ b/tests/Models/BaseModel.php
@@ -3,10 +3,13 @@
 namespace protich\AutoJoinEloquent\Tests\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use protich\AutoJoinEloquent\AutoJoinQueryBuilder;
 use protich\AutoJoinEloquent\Tests\Traits\AutoJoinTestTrait;
 
 /**
  * Base model for the auto-join test graph.
+ *
+ * @method static AutoJoinQueryBuilder query()
  */
 abstract class BaseModel extends Model
 {

--- a/tests/Models/Department.php
+++ b/tests/Models/Department.php
@@ -4,6 +4,8 @@ namespace protich\AutoJoinEloquent\Tests\Models;
 
 use protich\AutoJoinEloquent\Tests\Traits\AutoJoinTestTrait;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use protich\AutoJoinEloquent\Model\ExpressionDescriptor;
 use protich\AutoJoinEloquent\Model\PathRequest;
 
@@ -42,9 +44,9 @@ class Department extends Model
     /**
      * A department's manager is an agent.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     * @return BelongsTo<Agent,$this>
      */
-    public function manager()
+    public function manager(): BelongsTo
     {
         return $this->belongsTo(Agent::class, 'manager_id');
     }
@@ -52,9 +54,14 @@ class Department extends Model
     /**
      * A department belongs to many agents (via the pivot table).
      *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     * @return BelongsToMany<
+     *     Agent,
+     *     $this,
+     *     \Illuminate\Database\Eloquent\Relations\Pivot,
+     *     'pivot'
+     * >
      */
-    public function agents()
+    public function agents(): BelongsToMany
     {
         return $this->belongsToMany(Agent::class, 'agent_department', 'department_id', 'agent_id')
                     ->withPivot('assigned_at');
@@ -63,9 +70,14 @@ class Department extends Model
     /**
      * Get the groups assigned to this department.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     * @return BelongsToMany<
+     *     Group,
+     *     $this,
+     *     \Illuminate\Database\Eloquent\Relations\Pivot,
+     *     'pivot'
+     * >
      */
-    public function groups()
+    public function groups(): BelongsToMany
     {
         return $this->belongsToMany(
             Group::class,

--- a/tests/Models/Department.php
+++ b/tests/Models/Department.php
@@ -4,14 +4,40 @@ namespace protich\AutoJoinEloquent\Tests\Models;
 
 use protich\AutoJoinEloquent\Tests\Traits\AutoJoinTestTrait;
 use Illuminate\Database\Eloquent\Model;
+use protich\AutoJoinEloquent\Model\ExpressionDescriptor;
+use protich\AutoJoinEloquent\Model\PathRequest;
 
 class Department extends Model
 {
     use AutoJoinTestTrait;
 
+    /**
+     * Paths offered to this downstream model for description.
+     *
+     * @var list<string>
+     */
+    public static array $autoJoinPathRequests = [];
+
     protected $table = 'departments';
 
     protected $fillable = ['name', 'manager_id'];
+
+    /**
+     * Describe virtual expressions owned by the department model.
+     *
+     * @param  PathRequest $request
+     * @return ExpressionDescriptor|null
+     */
+    public static function describeAutoJoinPath(
+        PathRequest $request
+    ): ?ExpressionDescriptor {
+        self::$autoJoinPathRequests[] = $request->path;
+
+        return match ($request->path) {
+            'displayName' => ExpressionDescriptor::path('name'),
+            default => null,
+        };
+    }
 
     /**
      * A department's manager is an agent.

--- a/tests/Models/Group.php
+++ b/tests/Models/Group.php
@@ -3,6 +3,7 @@
 namespace protich\AutoJoinEloquent\Tests\Models;
 
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use protich\AutoJoinEloquent\Model\AutoJoinRelation;
 use protich\AutoJoinEloquent\Tests\Models\Department;
@@ -40,9 +41,9 @@ class Group extends BaseModel
     /**
      * Get the parent group.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     * @return BelongsTo<Group,$this>
      */
-    public function parent()
+    public function parent(): BelongsTo
     {
         return $this->belongsTo(Group::class, 'parent_id');
     }
@@ -50,9 +51,9 @@ class Group extends BaseModel
     /**
      * Get the child groups.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     * @return HasMany<Group,$this>
      */
-    public function children()
+    public function children(): HasMany
     {
         return $this->hasMany(Group::class, 'parent_id');
     }
@@ -93,9 +94,14 @@ class Group extends BaseModel
     /**
      * Get the agents assigned to this group.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     * @return BelongsToMany<
+     *     Agent,
+     *     $this,
+     *     \Illuminate\Database\Eloquent\Relations\Pivot,
+     *     'pivot'
+     * >
      */
-    public function agents()
+    public function agents(): BelongsToMany
     {
         return $this->belongsToMany(
             Agent::class,
@@ -108,9 +114,14 @@ class Group extends BaseModel
     /**
      * Get the departments assigned to this group.
      *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     * @return BelongsToMany<
+     *     Department,
+     *     $this,
+     *     \Illuminate\Database\Eloquent\Relations\Pivot,
+     *     'pivot'
+     * >
      */
-    public function departments()
+    public function departments(): BelongsToMany
     {
         return $this->belongsToMany(
             Department::class,
@@ -127,11 +138,14 @@ class Group extends BaseModel
      */
     public function qualifiedDepartments(): BelongsToMany
     {
-        return $this->belongsToMany(
+        $relation = $this->belongsToMany(
             Department::class,
             'group_departments',
             'group_id',
             'department_id'
-        )->where('departments.name', 'Support');
+        );
+        $relation->where('departments.name', 'Support');
+
+        return $relation;
     }
 }

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -4,6 +4,7 @@ namespace protich\AutoJoinEloquent\Tests\Models;
 
 use protich\AutoJoinEloquent\Tests\Traits\AutoJoinTestTrait;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 
 class User extends Model
 {
@@ -15,9 +16,9 @@ class User extends Model
 
     /**
      * A user is associated with an agent.
-     * @return \Illuminate\Database\Eloquent\Relations\HasOne
+     * @return HasOne<Agent,$this>
      */
-    public function agent()
+    public function agent(): HasOne
     {
         return $this->hasOne(Agent::class);
     }

--- a/tests/Seeder.php
+++ b/tests/Seeder.php
@@ -56,13 +56,27 @@ class Seeder
             throw new Exception("Schema file not found at: {$schemaFile}");
         }
 
-        /** @var array<string, array<string>> $schemaData */
         $schemaData = require $schemaFile;
-        if (!isset($schemaData['tables']) || !is_array($schemaData['tables'])) { // @phpstan-ignore-line
+
+        if (! is_array($schemaData)) {
+            throw new Exception('Schema file must return an array.');
+        }
+
+        $tables = $schemaData['tables'] ?? null;
+
+        if (! is_array($tables)) {
             throw new Exception("No 'tables' key found in schema file.");
         }
 
-        $this->tables = $schemaData['tables'];
+        foreach ($tables as $table) {
+            if (! is_string($table)) {
+                throw new Exception(
+                    "Schema 'tables' entries must be strings."
+                );
+            }
+        }
+
+        $this->tables = array_values($tables);
         $this->schemaFactory = $schemaData['factory'] ?? null;
     }
 
@@ -179,6 +193,14 @@ class Seeder
         if (!file_exists($file)) {
             throw new Exception("Seeder file not found: {$file}");
         }
-        return require $file; // @phpstan-ignore-line
+        $records = require $file;
+
+        if (! is_array($records)) {
+            throw new Exception(
+                "Seeder file must return an array: {$file}"
+            );
+        }
+
+        return $records;
     }
 }

--- a/tests/Setup/schemas/default/migrations/2003_01_01_0002_create_agents_table.php
+++ b/tests/Setup/schemas/default/migrations/2003_01_01_0002_create_agents_table.php
@@ -10,7 +10,7 @@ class CreateAgentsTable extends Migration
      * Create agents table.
      *
      * Includes flags column used for model-defined status paths
-     * (e.g. model__status → flags).
+     * (e.g. status → flags).
      *
      * @return void
      */

--- a/tests/Traits/AutoJoinTestTrait.php
+++ b/tests/Traits/AutoJoinTestTrait.php
@@ -28,8 +28,7 @@ trait AutoJoinTestTrait
      */
     public static function seed(array $data = []): void
     {
-        /** @phpstan-ignore-next-line */
-        $table = (new static)->getTable();
+        $table = static::query()->getModel()->getTable();
         Seeder::seedTable($table, $data);
     }
 }

--- a/tests/Unit/AccessibleDepartmentsCountTest.php
+++ b/tests/Unit/AccessibleDepartmentsCountTest.php
@@ -23,7 +23,7 @@ class AccessibleDepartmentsCountTest extends AutoJoinTestCase
     {
         $query = Agent::query()->select([
             'id',
-            'model__accessibleDepartments__id__count as accessible_departments_count',
+            'accessibleDepartments__id__count as accessible_departments_count',
         ]);
 
         $sql = $this->debugSql($query);
@@ -49,9 +49,9 @@ class AccessibleDepartmentsCountTest extends AutoJoinTestCase
         $query = Agent::query()
             ->select([
                 'id',
-                'model__accessibleDepartments__id__count as accessible_departments_count',
+                'accessibleDepartments__id__count as accessible_departments_count',
             ])
-            ->orderBy('model__accessibleDepartments__id__count', 'desc');
+            ->orderBy('accessibleDepartments__id__count', 'desc');
 
         $sql = $this->debugSql($query);
 
@@ -72,10 +72,10 @@ class AccessibleDepartmentsCountTest extends AutoJoinTestCase
         $query = Agent::query()
             ->select([
                 'id',
-                'model__accessibleDepartments__id__count as accessible_departments_count',
+                'accessibleDepartments__id__count as accessible_departments_count',
             ])
             ->groupBy('id')
-            ->having('model__accessibleDepartments__id__count', '>', 0); // @phpstan-ignore-line
+            ->having('accessibleDepartments__id__count', '>', 0); // @phpstan-ignore-line
 
         $sql = $this->debugSql($query);
 

--- a/tests/Unit/AccessibleDepartmentsCountTest.php
+++ b/tests/Unit/AccessibleDepartmentsCountTest.php
@@ -75,7 +75,7 @@ class AccessibleDepartmentsCountTest extends AutoJoinTestCase
                 'accessibleDepartments__id__count as accessible_departments_count',
             ])
             ->groupBy('id')
-            ->having('accessibleDepartments__id__count', '>', 0); // @phpstan-ignore-line
+            ->having('accessibleDepartments__id__count', '>', 0);
 
         $sql = $this->debugSql($query);
 

--- a/tests/Unit/AgentAggregateHavingTest.php
+++ b/tests/Unit/AgentAggregateHavingTest.php
@@ -28,7 +28,7 @@ class AgentAggregateHavingTest extends AutoJoinTestCase
             'name as agent_name',
             'COUNT(agent__departments.id) as dept_count'
         ])->groupBy('agent.id')
-          ->having('dept_count', '>', 1); // @phpstan-ignore-line
+          ->having('dept_count', '>', 1);
 
         // Retrieve the generated SQL via debugSql() for inspection.
         $sql = $this->debugSql($query);
@@ -49,7 +49,7 @@ class AgentAggregateHavingTest extends AutoJoinTestCase
         // Check first record
         $result = $query->first();
         // Verify that a record is returned.
-        $this->assertNotEmpty($result, 'A record should be returned from the query.');
+        $this->assertNotNull($result, 'A record should be returned from the query.');
         // Verify that the agent name is present.
         $this->assertNotNull($result->agent_name, 'The agent name should be returned.');
         // Verify that the department count is present and numeric.

--- a/tests/Unit/AgentAggregateTest.php
+++ b/tests/Unit/AgentAggregateTest.php
@@ -47,7 +47,7 @@ class AgentAggregateTest extends AutoJoinTestCase
 
         // Verify that the returned record contains the expected fields.
         $result = $query->first();
-        $this->assertNotEmpty($result, 'A record should be returned from the query.');
+        $this->assertNotNull($result, 'A record should be returned from the query.');
         $this->assertNotNull($result->agent_name, 'The agent name should be returned.');
         $this->assertNotNull($result->dept_count, 'The department count should be returned.');
         $this->assertIsNumeric($result->dept_count, 'The department count should be numeric.');

--- a/tests/Unit/BasicJoinsTest.php
+++ b/tests/Unit/BasicJoinsTest.php
@@ -34,7 +34,7 @@ class BasicJoinsTest extends AutoJoinTestCase
 
         // Assuming that your common seeders have created a user with name 'Peter Rotich' and an associated agent,
         // we can assert that the auto-join returned the expected data.
-        $this->assertNotEmpty($result, 'A result should be returned from the query.');
+        $this->assertNotNull($result, 'A result should be returned from the query.');
         $this->assertEquals('Peter Rotich', $result->name, 'The user name should match the seeded value.');
         $this->assertNotNull($result->agent_id, 'The agent id should be present from the auto-join.');
     }

--- a/tests/Unit/Builder/AccessibleDepartmentsDescriptorTest.php
+++ b/tests/Unit/Builder/AccessibleDepartmentsDescriptorTest.php
@@ -31,7 +31,7 @@ class AccessibleDepartmentsDescriptorTest extends AutoJoinTestCase
         );
 
         $this->assertSame(
-            'model__accessibleDepartments__id__count',
+            'accessibleDepartments__id__count',
             $described['path']
         );
         $this->assertInstanceOf(

--- a/tests/Unit/Builder/ModelDefinedPathTest.php
+++ b/tests/Unit/Builder/ModelDefinedPathTest.php
@@ -2,6 +2,7 @@
 
 namespace protich\AutoJoinEloquent\Tests\Unit\Builder;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use protich\AutoJoinEloquent\AutoJoinQueryBuilder;
 use protich\AutoJoinEloquent\Model\ExpressionDescriptor;
 use protich\AutoJoinEloquent\Tests\Models\Agent;
@@ -26,7 +27,7 @@ class ModelDefinedPathTest extends AutoJoinTestCase
 
         $described = $builder->describeModelDefinedPath('model__status');
 
-        $this->assertSame('model__status', $described['path']);
+        $this->assertSame('status', $described['path']);
         $this->assertInstanceOf(
             ExpressionDescriptor::class,
             $described['descriptor']
@@ -47,7 +48,7 @@ class ModelDefinedPathTest extends AutoJoinTestCase
         );
 
         $this->assertSame(
-            'model__accessibleDepartments__id__count',
+            'accessibleDepartments__id__count',
             $described['path']
         );
         $this->assertSame(
@@ -68,5 +69,191 @@ class ModelDefinedPathTest extends AutoJoinTestCase
         $this->expectException(\InvalidArgumentException::class);
 
         $builder->describeModelDefinedPath('model__');
+    }
+
+    /**
+     * Test model delegation still requires the reserved query marker.
+     */
+    public function test_unmarked_path_is_not_delegated_to_the_model(): void
+    {
+        $builder = Agent::query();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Column [status] is not a model-defined path.'
+        );
+
+        $builder->describeModelDefinedPath('status');
+    }
+
+    /**
+     * Test relation hooks receive the complete path without the marker.
+     */
+    public function test_relation_hook_receives_model_defined_path(): void
+    {
+        Agent::$autoJoinRelationDescriptions = [];
+
+        Agent::query()
+            ->select('model__userNamed__Alice as user_name')
+            ->toSql();
+
+        $this->assertContains([
+            'name' => 'userByName',
+            'path' => 'userNamed__Alice',
+        ], Agent::$autoJoinRelationDescriptions);
+    }
+
+    /**
+     * Test constraint variants receive independent aliases and bindings.
+     */
+    public function test_model_paths_keep_relationship_constraints_distinct(): void
+    {
+        $query = Agent::query()->select([
+            'model__userNamed__Alice as alice',
+            'model__userNamed__Bob as bob',
+        ]);
+
+        $sql = $query->toSql();
+
+        $this->assertSame(2, substr_count($sql, 'join "ost_users"'));
+        $this->assertStringContainsString(
+            '"B"."name" as "alice"',
+            $sql
+        );
+        $this->assertStringContainsString(
+            '"C"."name" as "bob"',
+            $sql
+        );
+        $this->assertSame(['Alice', 'Bob'], $query->getBindings());
+    }
+
+    /**
+     * Test identical constraint variants reuse their relationship join.
+     */
+    public function test_identical_model_paths_reuse_the_relationship_join(): void
+    {
+        $query = Agent::query()->select([
+            'model__userNamed__Alice as first_name',
+            'model__userNamed__Alice as second_name',
+        ]);
+
+        $this->assertSame(
+            1,
+            substr_count($query->toSql(), 'join "ost_users"')
+        );
+        $this->assertSame(['Alice'], $query->getBindings());
+    }
+
+    /**
+     * Test plain paths do not reuse model-defined constraints.
+     *
+     * @param  list<string> $columns
+     */
+    #[DataProvider('mixedPathOrderProvider')]
+    public function test_plain_and_model_paths_keep_constraints_separate(
+        array $columns
+    ): void {
+        $query = Agent::query()->select($columns);
+        $sql = $query->toSql();
+
+        $this->assertSame(2, substr_count($sql, 'join "ost_users"'));
+        $this->assertSame(1, substr_count($sql, '"name" = ?'));
+        $this->assertSame(['Alice'], $query->getBindings());
+    }
+
+    /**
+     * Provide both compilation orders for mixed path coverage.
+     *
+     * @return iterable<string,array{list<string>}>
+     */
+    public static function mixedPathOrderProvider(): iterable
+    {
+        yield 'model path first' => [[
+            'model__userNamed__Alice as constrained',
+            'userByName.name as plain',
+        ]];
+
+        yield 'plain path first' => [[
+            'userByName.name as plain',
+            'model__userNamed__Alice as constrained',
+        ]];
+    }
+
+    /**
+     * Test named-alias mode keeps constraint variant aliases unique.
+     */
+    public function test_named_alias_mode_keeps_variants_unique(): void
+    {
+        $query = Agent::query();
+        $query->setUseSimpleAliases(false);
+        $query->select([
+            'model__userNamed__Alice as alice',
+            'model__userNamed__Bob as bob',
+        ]);
+
+        $sql = $query->toSql();
+
+        $this->assertSame(2, substr_count($sql, 'join "ost_users"'));
+        $this->assertStringContainsString(
+            'as "userByName"',
+            $sql
+        );
+        $this->assertStringContainsString(
+            'as "userByName__',
+            $sql
+        );
+        $this->assertSame(['Alice', 'Bob'], $query->getBindings());
+    }
+
+    /**
+     * Test a single-path count retains its model-defined source path.
+     */
+    public function test_single_count_relationship_receives_model_path(): void
+    {
+        Agent::$autoJoinRelationDescriptions = [];
+
+        $query = Agent::query()
+            ->select('model__userNamed__Alice__count as matching_users');
+        $sql = $query->toSql();
+
+        $this->assertStringContainsString('COUNT(', $sql);
+        $this->assertSame(['Alice'], $query->getBindings());
+        $this->assertContains([
+            'name' => 'userByName',
+            'path' => 'userNamed__Alice__count',
+        ], Agent::$autoJoinRelationDescriptions);
+    }
+
+    /**
+     * Test multi-path count strategies retain the model-defined source path.
+     */
+    #[DataProvider('multiPathCountProvider')]
+    public function test_multi_path_count_relationships_receive_model_path(
+        string $path
+    ): void {
+        Agent::$autoJoinRelationDescriptions = [];
+
+        Agent::query()->select("{$path} as total")->toSql();
+        $modelPath = substr(
+            $path,
+            strlen(AutoJoinQueryBuilder::MODEL_PATH_PREFIX)
+        );
+
+        $this->assertNotEmpty(Agent::$autoJoinRelationDescriptions);
+
+        foreach (Agent::$autoJoinRelationDescriptions as $description) {
+            $this->assertSame($modelPath, $description['path']);
+        }
+    }
+
+    /**
+     * Provide EXISTS and UNION multi-path count descriptors.
+     *
+     * @return iterable<string,array{string}>
+     */
+    public static function multiPathCountProvider(): iterable
+    {
+        yield 'exists strategy' => ['model__qualifiedDepartmentCount'];
+        yield 'union strategy' => ['model__mixedComplexCount'];
     }
 }

--- a/tests/Unit/Builder/ModelDefinedPathTest.php
+++ b/tests/Unit/Builder/ModelDefinedPathTest.php
@@ -185,6 +185,22 @@ class ModelDefinedPathTest extends AutoJoinTestCase
     }
 
     /**
+     * Test compiled FROM expressions can pass through compilation again.
+     */
+    public function test_query_can_be_compiled_more_than_once(): void
+    {
+        $builder = Agent::query();
+        $query = $builder->getQuery();
+
+        $builder->autoJoinQuery($query);
+        $firstSql = $query->toSql();
+
+        $builder->autoJoinQuery($query);
+
+        $this->assertSame($firstSql, $query->toSql());
+    }
+
+    /**
      * Test relation hooks receive the complete path without the marker.
      */
     public function test_relation_hook_receives_model_defined_path(): void
@@ -337,9 +353,10 @@ class ModelDefinedPathTest extends AutoJoinTestCase
             strlen(AutoJoinQueryBuilder::MODEL_PATH_PREFIX)
         );
 
-        $this->assertNotEmpty(Agent::$autoJoinRelationDescriptions);
+        $descriptions = Agent::autoJoinRelationDescriptions();
+        $this->assertNotEmpty($descriptions);
 
-        foreach (Agent::$autoJoinRelationDescriptions as $description) {
+        foreach ($descriptions as $description) {
             $this->assertSame($modelPath, $description['path']);
         }
     }

--- a/tests/Unit/Builder/ModelDefinedPathTest.php
+++ b/tests/Unit/Builder/ModelDefinedPathTest.php
@@ -7,6 +7,8 @@ use protich\AutoJoinEloquent\AutoJoinQueryBuilder;
 use protich\AutoJoinEloquent\Model\ExpressionDescriptor;
 use protich\AutoJoinEloquent\Tests\Models\Agent;
 use protich\AutoJoinEloquent\Tests\AutoJoinTestCase;
+use protich\AutoJoinEloquent\Tests\Models\Department;
+use protich\AutoJoinEloquent\Tests\Models\User;
 
 /**
  * Test: ModelDefinedPathTest
@@ -84,6 +86,102 @@ class ModelDefinedPathTest extends AutoJoinTestCase
         );
 
         $builder->describeModelDefinedPath('status');
+    }
+
+    /**
+     * Test an unresolved root path is offered to the base model.
+     */
+    public function test_unresolved_root_path_is_described_by_model(): void
+    {
+        $described = Agent::query()->describeUnresolvedPath('status');
+
+        $this->assertNotNull($described);
+        $this->assertSame('status', $described['path']);
+        $this->assertSame(Agent::class, $described['model']);
+        $this->assertSame('flags', $described['descriptor']->getPath());
+    }
+
+    /**
+     * Test fallback occurs at the first unresolved downstream hop.
+     */
+    public function test_downstream_model_receives_only_unresolved_remainder(): void
+    {
+        Department::$autoJoinPathRequests = [];
+
+        $query = User::query()->select(
+            'agent__departments__displayName as department_name'
+        );
+        $sql = $query->toSql();
+
+        $this->assertSame(
+            ['displayName'],
+            Department::$autoJoinPathRequests
+        );
+        $this->assertStringContainsString(
+            '"D"."name" as "department_name"',
+            $sql
+        );
+    }
+
+    /**
+     * Test the explicit marker can route to a downstream model.
+     */
+    public function test_explicit_path_can_fall_back_at_downstream_hop(): void
+    {
+        Department::$autoJoinPathRequests = [];
+
+        $sql = User::query()->select(
+            'model__agent__departments__displayName as department_name'
+        )->toSql();
+
+        $this->assertSame(
+            ['displayName'],
+            Department::$autoJoinPathRequests
+        );
+        $this->assertStringContainsString(
+            '"D"."name" as "department_name"',
+            $sql
+        );
+    }
+
+    /**
+     * Test normal physical fields take precedence over model fallback.
+     */
+    public function test_physical_column_takes_precedence(): void
+    {
+        $builder = Agent::query();
+
+        $this->assertNull($builder->describeUnresolvedPath('position'));
+        $this->assertNull(
+            $builder->describeUnresolvedPath('departments__name')
+        );
+    }
+
+    /**
+     * Test a declined path preserves permissive legacy resolution.
+     */
+    public function test_declined_unknown_path_remains_permissive(): void
+    {
+        $builder = Agent::query();
+
+        $this->assertNull($builder->describeUnresolvedPath('whatever'));
+        $this->assertStringContainsString(
+            '"whatever" as "literal"',
+            $builder->select('whatever as literal')->toSql()
+        );
+    }
+
+    /**
+     * Test non-path expressions are never offered to a model.
+     */
+    public function test_literal_expressions_are_not_probed(): void
+    {
+        $builder = Agent::query();
+
+        $this->assertNull($builder->describeUnresolvedPath('1'));
+        $this->assertNull(
+            $builder->describeUnresolvedPath('"whatever"')
+        );
     }
 
     /**

--- a/tests/Unit/ColumnNormalizationTest.php
+++ b/tests/Unit/ColumnNormalizationTest.php
@@ -124,7 +124,7 @@ class ColumnNormalizationTest extends AutoJoinTestCase
         $query = User::query()
             ->select(['name', 'agent__departments__count as dept_count'])
             ->groupBy('agent.id')
-            ->having('agent__departments__count', '>', 0) // @phpstan-ignore-line
+            ->having('agent__departments__count', '>', 0)
             ->orderBy('name', 'asc');
 
         $sql = $this->debugSql($query);

--- a/tests/Unit/Compiler/ComplexRelationshipSubqueryTest.php
+++ b/tests/Unit/Compiler/ComplexRelationshipSubqueryTest.php
@@ -38,7 +38,10 @@ class ComplexRelationshipSubqueryTest extends AutoJoinTestCase
         $row = $query->first();
 
         $this->assertNotNull($row);
-        $this->assertSame(1, (int) $row->qualified_count);
+        $this->assertSame(
+            1,
+            $this->integerAttribute($row, 'qualified_count')
+        );
     }
 
     /**
@@ -67,7 +70,10 @@ class ComplexRelationshipSubqueryTest extends AutoJoinTestCase
         $row = $query->first();
 
         $this->assertNotNull($row);
-        $this->assertGreaterThan(0, (int) $row->mixed_count);
+        $this->assertGreaterThan(
+            0,
+            $this->integerAttribute($row, 'mixed_count')
+        );
     }
 
     /**
@@ -80,7 +86,7 @@ class ComplexRelationshipSubqueryTest extends AutoJoinTestCase
         $query = Agent::query()
             ->select('id')
             ->groupBy('id')
-            ->having('model__qualifiedDepartmentCount', '>', 0); // @phpstan-ignore-line
+            ->having('model__qualifiedDepartmentCount', '>', 0);
 
         $sql = $this->debugSql($query);
 
@@ -103,8 +109,8 @@ class ComplexRelationshipSubqueryTest extends AutoJoinTestCase
         $query = Agent::query()
             ->select('id')
             ->groupBy('id')
-            ->having('model__qualifiedDepartmentCount', '>', 0) // @phpstan-ignore-line
-            ->having('model__mixedComplexCount', '>', 0); // @phpstan-ignore-line
+            ->having('model__qualifiedDepartmentCount', '>', 0)
+            ->having('model__mixedComplexCount', '>', 0);
 
         $sql = $this->debugSql($query);
 
@@ -135,5 +141,31 @@ class ComplexRelationshipSubqueryTest extends AutoJoinTestCase
             $query->getBindings()
         );
         $this->assertNotEmpty($query->get());
+    }
+
+    /**
+     * Read an integer-valued projected model attribute.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model|\stdClass $model
+     * @param  string                                             $attribute
+     * @return int
+     */
+    private function integerAttribute(
+        \Illuminate\Database\Eloquent\Model|\stdClass $model,
+        string $attribute
+    ): int {
+        $value = $model instanceof \Illuminate\Database\Eloquent\Model
+            ? $model->getAttribute($attribute)
+            : ($model->{$attribute} ?? null);
+
+        if (! is_numeric($value)) {
+            throw new \UnexpectedValueException(sprintf(
+                'Projected attribute [%s] must be numeric; [%s] given.',
+                $attribute,
+                get_debug_type($value)
+            ));
+        }
+
+        return (int) $value;
     }
 }

--- a/tests/Unit/Compiler/ModelDefinedPathCompilerTest.php
+++ b/tests/Unit/Compiler/ModelDefinedPathCompilerTest.php
@@ -87,4 +87,91 @@ class ModelDefinedPathCompilerTest extends AutoJoinTestCase
 
         $this->assertSame($expected, $actual);
     }
+
+    /**
+     * Test an unmarked path falls back to the model in SELECT.
+     */
+    public function test_unmarked_status_compiles_in_select(): void
+    {
+        $expected = Agent::query()->select('flags')->toSql();
+        $actual = Agent::query()->select('status')->toSql();
+
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Test an unmarked path falls back to the model in WHERE.
+     */
+    public function test_unmarked_status_compiles_in_where(): void
+    {
+        $expected = Agent::query()->where('flags', 1)->toSql();
+        $actual = Agent::query()->where('status', 1)->toSql();
+
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Test an unmarked path falls back to the model in ORDER BY.
+     */
+    public function test_unmarked_status_compiles_in_order_by(): void
+    {
+        $expected = Agent::query()->orderBy('flags')->toSql();
+        $actual = Agent::query()->orderBy('status')->toSql();
+
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Test bitwise raw SQL resolves an unmarked model path.
+     */
+    public function test_unmarked_status_compiles_in_bitwise_raw_sql(): void
+    {
+        $expected = Agent::query()
+            ->whereRaw('flags & ? = 0', [1])
+            ->toSql();
+        $actual = Agent::query()
+            ->whereRaw('status & ? = 0', [1])
+            ->toSql();
+
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Test COALESCE resolves its model-described arguments.
+     */
+    public function test_unmarked_status_compiles_in_coalesce(): void
+    {
+        $sql = Agent::query()
+            ->select('COALESCE(status, flags) as current_status')
+            ->toSql();
+
+        $this->assertStringContainsString(
+            'COALESCE("A"."flags", "A"."flags") as "current_status"',
+            $sql
+        );
+    }
+
+    /**
+     * Test descriptors can resolve through another model expression.
+     */
+    public function test_descriptors_can_reference_other_model_expressions(): void
+    {
+        $expected = Agent::query()->select('flags')->toSql();
+        $actual = Agent::query()->select('statusAlias')->toSql();
+
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Test recursive model descriptions fail with an actionable error.
+     */
+    public function test_circular_model_expression_throws(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(
+            'Circular model-defined auto-join path [circularExpression]'
+        );
+
+        Agent::query()->select('circularExpression')->toSql();
+    }
 }

--- a/tests/Unit/CompleteAutoJoinTest.php
+++ b/tests/Unit/CompleteAutoJoinTest.php
@@ -6,6 +6,7 @@ use protich\AutoJoinEloquent\Tests\AutoJoinTestCase;
 use protich\AutoJoinEloquent\Tests\Models\User;
 use protich\AutoJoinEloquent\Tests\Models\Agent;
 use protich\AutoJoinEloquent\Tests\Models\Department;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 
 /**
  * Inline UserStaff model extending User, providing a custom alias for 'agent'.
@@ -25,9 +26,9 @@ class UserStaff extends User
 
     /**
      * Summary of agent
-     * @return \Illuminate\Database\Eloquent\Relations\HasOne
+     * @return HasOne<Agent,$this>
      */
-    public function agent()
+    public function agent(): HasOne
     {
         return $this->hasOne(Agent::class, 'user_id');
     }
@@ -50,7 +51,7 @@ class CompleteAutoJoinTest extends AutoJoinTestCase
         ])
         ->where('agent.id', '=', 1)
         ->groupBy('agent.id')
-        ->having('dept_count', '>', 1) // @phpstan-ignore-line
+        ->having('dept_count', '>', 1)
         ->orderBy('name', 'asc');
 
         $sql = $this->debugSql($query);

--- a/tests/Unit/ComplexRelationshipTest.php
+++ b/tests/Unit/ComplexRelationshipTest.php
@@ -246,7 +246,9 @@ class ComplexRelationshipTest extends AutoJoinTestCase
 
         $this->assertCount($agentCount, $leftRows);
         $this->assertCount(1, $innerRows);
-        $this->assertSame('Alice', $innerRows->first()->matched_name);
+        $innerRow = $innerRows->first();
+        $this->assertNotNull($innerRow);
+        $this->assertSame('Alice', $innerRow->matched_name);
         $this->assertSame(
             $agentCount - 1,
             $leftRows->whereNull('matched_name')->count()

--- a/tests/Unit/CustomAliasTest.php
+++ b/tests/Unit/CustomAliasTest.php
@@ -5,6 +5,7 @@ namespace protich\AutoJoinEloquent\Tests;
 use protich\AutoJoinEloquent\Traits\AutoJoinTrait;
 use protich\AutoJoinEloquent\Tests\Models\User;
 use protich\AutoJoinEloquent\Tests\Models\Agent;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 
 class UserStaff extends User
 {
@@ -20,9 +21,9 @@ class UserStaff extends User
     ];
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasOne
+     * @return HasOne<Agent,$this>
      */
-    public function agent()
+    public function agent(): HasOne
     {
         return $this->hasOne(Agent::class, 'user_id');
     }

--- a/tests/Unit/Model/PathRequestTest.php
+++ b/tests/Unit/Model/PathRequestTest.php
@@ -19,11 +19,11 @@ class PathRequestTest extends TestCase
     public function test_preserves_the_complete_path(): void
     {
         $request = new PathRequest(
-            'model__accessibleDepartments__id__count'
+            'accessibleDepartments__id__count'
         );
 
         $this->assertSame(
-            'model__accessibleDepartments__id__count',
+            'accessibleDepartments__id__count',
             $request->path
         );
     }
@@ -35,39 +35,9 @@ class PathRequestTest extends TestCase
      */
     public function test_trims_surrounding_whitespace(): void
     {
-        $request = new PathRequest('  model__status__label  ');
+        $request = new PathRequest('  status__label  ');
 
-        $this->assertSame('model__status__label', $request->path);
-    }
-
-    /**
-     * Ensure a path without the reserved marker is rejected.
-     *
-     * @return void
-     */
-    public function test_rejects_a_path_without_the_model_marker(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(
-            'Auto-join model path [status] must begin with [model__].'
-        );
-
-        new PathRequest('status');
-    }
-
-    /**
-     * Ensure the marker alone is not considered a model-defined path.
-     *
-     * @return void
-     */
-    public function test_rejects_the_model_marker_without_a_path(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage(
-            'Auto-join model path [model__] must begin with [model__].'
-        );
-
-        new PathRequest('model__');
+        $this->assertSame('status__label', $request->path);
     }
 
     /**
@@ -78,6 +48,9 @@ class PathRequestTest extends TestCase
     public function test_rejects_an_empty_path(): void
     {
         $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'Auto-join model path must not be empty.'
+        );
 
         new PathRequest('   ');
     }

--- a/tests/Unit/NestedDotNotationWhereWithBindingsTest.php
+++ b/tests/Unit/NestedDotNotationWhereWithBindingsTest.php
@@ -58,7 +58,7 @@ class NestedDotNotationWhereWithBindingsTest extends AutoJoinTestCase
         $result = $query->first();
 
         // Verify that the returned record contains the expected fields.
-        $this->assertNotEmpty($result, 'A record should be returned from the query.');
+        $this->assertNotNull($result, 'A record should be returned from the query.');
         $this->assertNotNull($result->agent_id, 'Agent id should be present from the nested join.');
         $this->assertNotNull($result->dept_name, 'Department name should be present from the nested join.');
     }

--- a/tests/Unit/NestedJoinsWithInnerAgentTest.php
+++ b/tests/Unit/NestedJoinsWithInnerAgentTest.php
@@ -42,7 +42,7 @@ class NestedJoinsWithInnerAgentTest extends AutoJoinTestCase
 
         // Verify that the returned record contains the expected fields.
         $result = $query->first();
-        $this->assertNotEmpty($result, 'A record should be returned from the query.');
+        $this->assertNotNull($result, 'A record should be returned from the query.');
         $this->assertNotNull($result->agent_id, 'Agent id should be present from the inner join.');
         $this->assertNotNull($result->dept_name, 'Department name should be present from the nested join.');
         $this->assertNotNull($result->mgr_name, 'Manager name should be present from the nested join.');

--- a/tests/Unit/SuffixCountsTest.php
+++ b/tests/Unit/SuffixCountsTest.php
@@ -72,7 +72,7 @@ class SuffixCountsTest extends AutoJoinTestCase
                 'agent__departments.id__count as dept_count',
             ])
             ->groupBy('agent.id')
-            ->having('agent__departments.id__count', '>', 0); // @phpstan-ignore-line
+            ->having('agent__departments.id__count', '>', 0);
 
         $sql = $this->debugSql($query);
 


### PR DESCRIPTION
This PR extends the typed model API introduced in v0.10 by making model-defined expression resolution hop-local. Auto-join now resolves normal columns and relationships before asking the model at the first unresolved hop to describe the intact remaining path.

It also preserves constrained relationship variants, strengthens descriptor rebasing throughout the query pipeline, and aligns compiler expression types with Laravel 13.

This allows downstream users to describe domain-specific expressions at the model that owns them without teaching auto-joiner domain behavior or requiring base models to interpret every path.

## Changes

### Hop-Local Model Expressions

Normal fields and Eloquent relationships are resolved before model-defined expressions. When resolution reaches an unknown segment, the model at that hop receives the complete unresolved remainder.

For example:

```text
organization__cdata__field_id__42
```

Auto-join resolves `organization` and `cdata` normally. The CData model then receives:

```php
new PathRequest('field_id__42')
```

The model can describe the expression relative to itself:

```php
public static function describeAutoJoinPath(
    PathRequest $request
): ?ExpressionDescriptor {
    return match ($request->path) {
        'field_id__42' => ExpressionDescriptor::path(
            'values.field_value'
        ),
        default => null,
    };
}
```

The returned descriptor is rebased onto the relationships already resolved by the package.

This keeps path segmentation inside auto-joiner while allowing each model to describe only the expressions it owns.

### Nullable Expression Ownership

`describeAutoJoinPath()` now returns `?ExpressionDescriptor`.

Returning `null` indicates that the model does not own the unresolved expression. This preserves permissive handling for unknown columns and literal expressions such as `1` or `"whatever"`.

Models should continue throwing exceptions when they recognize an expression but determine that it is invalid.

Normal physical columns and relationships take precedence over model-defined expressions with the same name.

### Explicit Model Delegation

The optional `model__` marker remains available as an explicit compatibility escape hatch.

The marker is treated as package-level routing metadata and is stripped before invoking model path and relationship hooks. It is not exposed as a downstream application convention.

Explicitly marked paths ask the base model first. When the base model declines the expression, resolution continues using the same hop-local behavior as an unmarked path.

### Descriptor Rebasing

Model-owned descriptors are relative to the model that returned them.
Auto-join rebases their paths onto the relationship prefix resolved before model delegation.

Rebased descriptors are supported throughout:

- SELECT
- WHERE
- GROUP BY
- HAVING
- ORDER BY
- aggregate expressions
- count descriptors

Nested model descriptors retain circular-reference protection, aliases, bindings, and aggregate behavior.

### Constraint-Aware Relationship Variants

Complete model-defined paths are propagated through relationship resolution so models can derive relationship constraints from the requested expression.

Different constraints against the same Eloquent relationship are maintained as separate relationship variants. For example, expressions requesting `userNamed__Alice` and `userNamed__Bob` receive independent joins, aliases, and bindings.

Equivalent constraint signatures reuse an existing join, while different signatures remain isolated in both sequential and named alias modes.

Source paths are preserved through direct joins, single-path counts, EXISTS counts, and UNION count strategies.

### Laravel 13 Expression Contract

`CompiledExpression` now implements Laravel's query expression contract directly.

This avoids treating compiler-generated SQL as a literal static expression and tightens the boundaries between resolved paths, compiled SQL, and Laravel query clauses.

The compiler changes also:

- validate SELECT and FROM expression values
- preserve repeated query compilation
- maintain subquery binding offsets
- validate custom compiler return types
- improve builder, compiler, join, and relationship types

### Static Analysis

The source and test suites now pass PHPStan at maximum level without configuration exclusions, inline suppressions, or a baseline.

Relationship generics, nullable query results, environment inputs, schema definitions, seed data, and compiler contracts are explicitly narrowed or validated.

### Runtime and Upgrade Contract

The release retains the runtime targets introduced in v0.10:

- PHP 8.3
- Illuminate Database 13
- PHPUnit 11
- Orchestra Testbench 11

`UPGRADING.md` documents the nullable model hook, hop-local ownership, relative descriptor paths, and continued support for explicit `model__` delegation.

The package version is bumped to `v0.11.0`.

## Testing Coverage

The package test suite passes with:

- 112 tests
- 341 assertions

Coverage includes:

- root and downstream model expressions
- normal column and relationship precedence
- nullable ownership and unknown expressions
- explicit marker fallback
- descriptor rebasing across query clauses
- relationship constraint isolation and reuse
- sequential and named aliases
- direct, count, EXISTS, and UNION resolution
- circular descriptor detection
- repeated compilation and binding offsets
- Laravel expression-contract compatibility

The focused model API analysis and the complete PHPStan level-max analysis both pass cleanly.

A downstream compatibility suite using the local Composer path dependency also passes with 38 tests and 95 assertions.

## Review Focus

Please pay particular attention to:

- whether the first unresolved hop is the correct model ownership boundary
- nullable expression ownership and fallback behavior
- keeping `model__` as package-level routing metadata
- downstream descriptor rebasing
- constrained relationship variant isolation and reuse
- source-path propagation through aggregate strategies
- Laravel 13 expression handling and repeated compilation
- the v0.11 upgrade guidance