### PR TITLE
 feat(expressions): complete typed descriptor vocabulary

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,16 @@ public static function describeAutoJoinPath(
                 'groups.departments.id',
             ], distinct: true),
 
+        'preferredContact' => ExpressionDescriptor::coalesce([
+            'phone',
+            'email',
+        ]),
+
+        'serviceLabel' => ExpressionDescriptor::concat(
+            ['parent.name', 'name'],
+            ' / '
+        ),
+
         default => null,
     };
 }
@@ -161,6 +171,18 @@ The returned `ExpressionDescriptor` tells the package how to compile the
 logical expression. For example,
 `organization__cdata__field_id__42` traverses `organization` and `cdata`
 normally, then offers only `field_id__42` to the CData model.
+
+The typed descriptor vocabulary mirrors the column compiler:
+
+- `path()` resolves another local or relationship path.
+- `count()` supports one path or a distinct union of multiple paths.
+- `sum()`, `avg()`, `min()`, and `max()` describe scalar aggregates.
+- `coalesce()` returns the first non-null value from ordered paths.
+- `concat()` joins ordered, non-null path values with a fixed separator.
+
+Every path remains relative to the model that owns the expression. Composite
+and aggregate descriptors are rebased when they are reached through upstream
+relationships, just like ordinary path descriptors.
 
 The optional `model__` marker remains supported as an explicit compatibility
 escape hatch. It asks the base model first and, when declined, follows the same

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,38 @@
 # Upgrading Auto Join Eloquent
 
+## From 0.11.0 to 0.11.1
+
+Version 0.11.1 completes the typed `ExpressionDescriptor` vocabulary. No
+application changes are required for existing `path()` or `count()`
+descriptors.
+
+Models may now describe every scalar expression family supported by the
+column compiler:
+
+```php
+return match ($request->path) {
+    'total' => ExpressionDescriptor::sum('items.amount'),
+    'average' => ExpressionDescriptor::avg('items.amount'),
+    'minimum' => ExpressionDescriptor::min('items.amount'),
+    'maximum' => ExpressionDescriptor::max('items.amount'),
+    'contact' => ExpressionDescriptor::coalesce(['phone', 'email']),
+    'label' => ExpressionDescriptor::concat(
+        ['parent.name', 'name'],
+        ' / '
+    ),
+    default => null,
+};
+```
+
+`concat()` uses null-skipping semantics, so an absent parent in the example
+produces `name` without a leading separator. Composite paths are rebased when
+the owning model is reached through another relationship.
+
+Direct scalar aggregate descriptors now follow the same clause rule as parsed
+aggregate expressions and are rejected in `WHERE`. Use `HAVING` for `sum()`,
+`avg()`, `min()`, and `max()` criteria. Multi-path `count()` descriptors remain
+valid in `WHERE` because they compile to correlated scalar subqueries.
+
 ## From 0.10 to 0.11
 
 Version 0.11 resolves normal columns and relationships before asking the model

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "protich/auto-join-eloquent",
   "description": "Extend Eloquent to support auto-joining relationships and aliasing for SELECT, WHERE, ORDERBY, GROUPBY and HAVING clauses",
   "type": "library",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "license": "MIT",
   "authors": [
     {

--- a/src/AutoJoinQueryBuilder.php
+++ b/src/AutoJoinQueryBuilder.php
@@ -904,6 +904,33 @@ class AutoJoinQueryBuilder extends EloquentBuilder
                     $paths,
                     $descriptor->distinct()
                 ),
+            ExpressionDescriptor::TYPE_SUM =>
+                ExpressionDescriptor::sum(
+                    $paths[0],
+                    $descriptor->distinct()
+                ),
+            ExpressionDescriptor::TYPE_AVG =>
+                ExpressionDescriptor::avg(
+                    $paths[0],
+                    $descriptor->distinct()
+                ),
+            ExpressionDescriptor::TYPE_MIN =>
+                ExpressionDescriptor::min(
+                    $paths[0],
+                    $descriptor->distinct()
+                ),
+            ExpressionDescriptor::TYPE_MAX =>
+                ExpressionDescriptor::max(
+                    $paths[0],
+                    $descriptor->distinct()
+                ),
+            ExpressionDescriptor::TYPE_COALESCE =>
+                ExpressionDescriptor::coalesce($paths),
+            ExpressionDescriptor::TYPE_CONCAT =>
+                ExpressionDescriptor::concat(
+                    $paths,
+                    $descriptor->separator() ?? ''
+                ),
             default => throw new \RuntimeException(sprintf(
                 'Unsupported expression descriptor type [%s].',
                 $descriptor->type()

--- a/src/Compilers/BaseCompiler.php
+++ b/src/Compilers/BaseCompiler.php
@@ -482,14 +482,23 @@ abstract class BaseCompiler
      * @return CompiledExpression
      */
     protected function compileCoalesceExpression(
-        array $info
+        array $info,
+        ?string $relationshipPath = null
     ): CompiledExpression
     {
         $grammar = $this->builder->getGrammar();
 
-        $resolved = array_map(function (string $field) use ($grammar): string {
+        $resolved = array_map(function (string $field) use (
+            $grammar,
+            $relationshipPath
+        ): string {
             $column = $this->parseColumnParts($field)['column'];
-            $expr = $this->resolveColumnExpression($column, null, false);
+            $expr = $this->resolveColumnExpression(
+                $column,
+                null,
+                false,
+                $relationshipPath
+            );
 
             return $expr->getValue($grammar);
         }, $info['fields']);
@@ -630,6 +639,30 @@ abstract class BaseCompiler
                         $allowAlias,
                         $modelPath['path']
                     ),
+                ExpressionDescriptor::TYPE_SUM,
+                ExpressionDescriptor::TYPE_AVG,
+                ExpressionDescriptor::TYPE_MIN,
+                ExpressionDescriptor::TYPE_MAX =>
+                    $this->compileModelAggregateDescriptor(
+                        $descriptor,
+                        $alias,
+                        $allowAlias,
+                        $modelPath['path']
+                    ),
+                ExpressionDescriptor::TYPE_COALESCE =>
+                    $this->compileModelCoalesceDescriptor(
+                        $descriptor,
+                        $alias,
+                        $allowAlias,
+                        $modelPath['path']
+                    ),
+                ExpressionDescriptor::TYPE_CONCAT =>
+                    $this->compileModelConcatDescriptor(
+                        $descriptor,
+                        $alias,
+                        $allowAlias,
+                        $modelPath['path']
+                    ),
                 default => throw new \RuntimeException(sprintf(
                     'Unsupported model-defined descriptor type [%s] for path [%s].',
                     $descriptor->type(),
@@ -711,6 +744,109 @@ abstract class BaseCompiler
             $allowAlias ? $alias : null,
             $allowAlias,
             $sourcePath
+        );
+    }
+
+    /**
+     * Compile a scalar aggregate model descriptor.
+     *
+     * @param  ExpressionDescriptor $descriptor
+     * @param  string|null          $alias
+     * @param  bool                 $allowAlias
+     * @param  string               $sourcePath
+     * @return CompiledExpression
+     */
+    protected function compileModelAggregateDescriptor(
+        ExpressionDescriptor $descriptor,
+        ?string $alias,
+        bool $allowAlias,
+        string $sourcePath
+    ): CompiledExpression {
+        $function = $descriptor->aggregateFunction();
+        $path = $descriptor->paths()[0] ?? null;
+
+        if ($function === null || $path === null) {
+            throw new \LogicException(
+                'Aggregate descriptors require a function and path.'
+            );
+        }
+
+        return $this->compileAggregateExpression(
+            [
+                'aggregateFunction' => $function,
+                'innerExpression' => $path,
+                'alias' => $allowAlias ? $alias : null,
+                'outerExpression' => '',
+                'distinct' => $descriptor->distinct(),
+            ],
+            $allowAlias && $alias === null,
+            $sourcePath
+        );
+    }
+
+    /**
+     * Compile an ordered first-non-null model descriptor.
+     *
+     * @param  ExpressionDescriptor $descriptor
+     * @param  string|null          $alias
+     * @param  bool                 $allowAlias
+     * @param  string               $sourcePath
+     * @return CompiledExpression
+     */
+    protected function compileModelCoalesceDescriptor(
+        ExpressionDescriptor $descriptor,
+        ?string $alias,
+        bool $allowAlias,
+        string $sourcePath
+    ): CompiledExpression {
+        return $this->compileCoalesceExpression(
+            [
+                'fields' => $descriptor->paths(),
+                'alias' => $allowAlias ? $alias : null,
+            ],
+            $sourcePath
+        );
+    }
+
+    /**
+     * Compile null-skipping path concatenation with a fixed separator.
+     *
+     * @param  ExpressionDescriptor $descriptor
+     * @param  string|null          $alias
+     * @param  bool                 $allowAlias
+     * @param  string               $sourcePath
+     * @return CompiledExpression
+     */
+    protected function compileModelConcatDescriptor(
+        ExpressionDescriptor $descriptor,
+        ?string $alias,
+        bool $allowAlias,
+        string $sourcePath
+    ): CompiledExpression {
+        $grammar = $this->builder->getGrammar();
+        $resolved = array_map(
+            function (string $path) use ($grammar, $sourcePath): string {
+                $column = $this->parseColumnParts($path)['column'];
+                $expression = $this->resolveColumnExpression(
+                    $column,
+                    null,
+                    false,
+                    $sourcePath
+                );
+
+                return $expression->getValue($grammar);
+            },
+            $descriptor->paths()
+        );
+        $separator = $grammar->escape($descriptor->separator() ?? '');
+
+        return $this->makeCompiledExpression(
+            sprintf(
+                'CONCAT_WS(%s, %s)',
+                $separator,
+                implode(', ', $resolved)
+            ),
+            $allowAlias ? $alias : null
         );
     }
 

--- a/src/Compilers/WhereCompiler.php
+++ b/src/Compilers/WhereCompiler.php
@@ -2,15 +2,16 @@
 
 namespace protich\AutoJoinEloquent\Compilers;
 
-use Illuminate\Database\Query\Builder;
-use protich\AutoJoinEloquent\Support\CompiledExpression;
 use Exception;
+use Illuminate\Database\Query\Builder;
+use protich\AutoJoinEloquent\Model\ExpressionDescriptor;
+use protich\AutoJoinEloquent\Support\CompiledExpression;
 
 /**
  * WhereCompiler
  *
  * Compiles WHERE clause column expressions.
- * Disallows aggregates (e.g. COUNT, SUM) and supports COALESCE with aliasing disabled.
+ * Disallows direct aggregates and supports scalar descriptor expressions.
  */
 class WhereCompiler extends BaseCompiler
 {
@@ -22,9 +23,8 @@ class WhereCompiler extends BaseCompiler
     /**
      * Compile a WHERE clause column expression.
      *
-     * WHERE clauses do not support SQL aliases or aggregate functions.
-     * This method throws if an aggregate is detected, and otherwise delegates
-     * to the base compiler with aliasing explicitly disabled.
+     * WHERE clauses do not support SQL aliases or direct aggregate functions.
+     * Correlated count descriptors remain valid scalar subqueries.
      *
      * @param string $column The raw column expression.
      * @param bool $allowAlias Required by interface; always ignored (false).
@@ -37,6 +37,17 @@ class WhereCompiler extends BaseCompiler
     ): CompiledExpression
     {
         if ($modelPath = $this->parseDescribedPathExpression($column)) {
+            if (in_array($modelPath['descriptor']->type(), [
+                ExpressionDescriptor::TYPE_SUM,
+                ExpressionDescriptor::TYPE_AVG,
+                ExpressionDescriptor::TYPE_MIN,
+                ExpressionDescriptor::TYPE_MAX,
+            ], true)) {
+                throw new Exception(
+                    'Aggregate expressions are not allowed in WHERE clauses.'
+                );
+            }
+
             return $this->compileModelDefinedPath($modelPath, false);
         }
 

--- a/src/Model/ExpressionDescriptor.php
+++ b/src/Model/ExpressionDescriptor.php
@@ -31,16 +31,36 @@ final readonly class ExpressionDescriptor
     public const TYPE_COUNT = 'count';
 
     /**
+     * Descriptor types for scalar aggregate expressions.
+     */
+    public const TYPE_SUM = 'sum';
+    public const TYPE_AVG = 'avg';
+    public const TYPE_MIN = 'min';
+    public const TYPE_MAX = 'max';
+
+    /**
+     * Descriptor type for the first non-null value across multiple paths.
+     */
+    public const TYPE_COALESCE = 'coalesce';
+
+    /**
+     * Descriptor type for null-skipping path concatenation.
+     */
+    public const TYPE_CONCAT = 'concat';
+
+    /**
      * Create a normalized immutable descriptor.
      *
      * @param  string        $type
      * @param  list<string>  $paths
      * @param  bool          $distinct
+     * @param  string|null   $separator
      */
     private function __construct(
         private string $type,
         private array $paths,
-        private bool $distinct = false
+        private bool $distinct = false,
+        private ?string $separator = null
     ) {
     }
 
@@ -76,16 +96,71 @@ final readonly class ExpressionDescriptor
     {
         $paths = is_string($paths) ? [$paths] : array_values($paths);
 
-        if ($paths === []) {
-            throw new InvalidArgumentException(
-                'Count expression descriptor requires at least one path.'
-            );
-        }
-
         return new self(
             self::TYPE_COUNT,
-            array_map(self::normalizePath(...), $paths),
+            self::normalizePaths($paths, 'Count'),
             $distinct
+        );
+    }
+
+    /**
+     * Describe a SUM aggregate over one auto-join path.
+     */
+    public static function sum(string $path, bool $distinct = false): self
+    {
+        return self::aggregate(self::TYPE_SUM, $path, $distinct);
+    }
+
+    /**
+     * Describe an AVG aggregate over one auto-join path.
+     */
+    public static function avg(string $path, bool $distinct = false): self
+    {
+        return self::aggregate(self::TYPE_AVG, $path, $distinct);
+    }
+
+    /**
+     * Describe a MIN aggregate over one auto-join path.
+     */
+    public static function min(string $path, bool $distinct = false): self
+    {
+        return self::aggregate(self::TYPE_MIN, $path, $distinct);
+    }
+
+    /**
+     * Describe a MAX aggregate over one auto-join path.
+     */
+    public static function max(string $path, bool $distinct = false): self
+    {
+        return self::aggregate(self::TYPE_MAX, $path, $distinct);
+    }
+
+    /**
+     * Describe a COALESCE expression over ordered auto-join paths.
+     *
+     * @param  array<int,string>  $paths
+     */
+    public static function coalesce(array $paths): self
+    {
+        return new self(
+            self::TYPE_COALESCE,
+            self::normalizePaths($paths, 'Coalesce', 2)
+        );
+    }
+
+    /**
+     * Describe null-skipping concatenation over ordered auto-join paths.
+     *
+     * @param  array<int,string>  $paths
+     */
+    public static function concat(
+        array $paths,
+        string $separator = ''
+    ): self {
+        return new self(
+            self::TYPE_CONCAT,
+            self::normalizePaths($paths, 'Concat', 2),
+            separator: $separator
         );
     }
 
@@ -114,8 +189,8 @@ final readonly class ExpressionDescriptor
     /**
      * Get all paths carried by the descriptor.
      *
-     * Path descriptors contain one entry; count descriptors may contain one
-     * or more entries.
+     * Path and scalar aggregate descriptors contain one entry. Count and
+     * composite descriptors may contain multiple ordered paths.
      *
      * @return list<string>
      */
@@ -125,13 +200,76 @@ final readonly class ExpressionDescriptor
     }
 
     /**
-     * Determine whether count compilation should use distinct semantics.
+     * Determine whether aggregate compilation should use distinct semantics.
      *
      * @return bool
      */
     public function distinct(): bool
     {
         return $this->distinct;
+    }
+
+    /**
+     * Get the SQL aggregate function represented by this descriptor.
+     */
+    public function aggregateFunction(): ?string
+    {
+        return match ($this->type) {
+            self::TYPE_COUNT => 'COUNT',
+            self::TYPE_SUM => 'SUM',
+            self::TYPE_AVG => 'AVG',
+            self::TYPE_MIN => 'MIN',
+            self::TYPE_MAX => 'MAX',
+            default => null,
+        };
+    }
+
+    /**
+     * Get the separator for a concatenation descriptor.
+     */
+    public function separator(): ?string
+    {
+        return $this->separator;
+    }
+
+    /**
+     * Create a normalized single-path aggregate descriptor.
+     */
+    private static function aggregate(
+        string $type,
+        string $path,
+        bool $distinct
+    ): self {
+        return new self(
+            $type,
+            [self::normalizePath($path)],
+            $distinct
+        );
+    }
+
+    /**
+     * Normalize and validate an ordered path list.
+     *
+     * @param  array<int,string>  $paths
+     * @return list<string>
+     */
+    private static function normalizePaths(
+        array $paths,
+        string $descriptor,
+        int $minimum = 1
+    ): array {
+        $paths = array_values($paths);
+
+        if (count($paths) < $minimum) {
+            throw new InvalidArgumentException(sprintf(
+                '%s expression descriptor requires at least %s path%s.',
+                $descriptor,
+                $minimum === 1 ? 'one' : (string) $minimum,
+                $minimum === 1 ? '' : 's'
+            ));
+        }
+
+        return array_map(self::normalizePath(...), $paths);
     }
 
     /**

--- a/tests/Models/Agent.php
+++ b/tests/Models/Agent.php
@@ -109,6 +109,30 @@ class Agent extends BaseModel
                 ],
                 distinct: true
             ),
+            'departmentIdSum' => ExpressionDescriptor::sum(
+                'departments.id'
+            ),
+            'departmentIdAverage' => ExpressionDescriptor::avg(
+                'departments.id'
+            ),
+            'departmentIdMinimum' => ExpressionDescriptor::min(
+                'departments.id'
+            ),
+            'departmentIdMaximum' => ExpressionDescriptor::max(
+                'departments.id'
+            ),
+            'preferredContact' => ExpressionDescriptor::coalesce([
+                'user.phone',
+                'user.email',
+            ]),
+            'displayLabel' => ExpressionDescriptor::concat(
+                ['user.name', 'position'],
+                ' / '
+            ),
+            'contactLabel' => ExpressionDescriptor::concat(
+                ['user.phone', 'user.email'],
+                ' / '
+            ),
             default => parent::describeAutoJoinPath($request),
         };
     }

--- a/tests/Models/Group.php
+++ b/tests/Models/Group.php
@@ -6,6 +6,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use protich\AutoJoinEloquent\Model\AutoJoinRelation;
+use protich\AutoJoinEloquent\Model\ExpressionDescriptor;
+use protich\AutoJoinEloquent\Model\PathRequest;
 use protich\AutoJoinEloquent\Tests\Models\Department;
 
 /**
@@ -37,6 +39,24 @@ class Group extends BaseModel
         'name',
         'parent_id',
     ];
+
+    /**
+     * Describe the qualified label used by flat hierarchy surfaces.
+     *
+     * @param  PathRequest  $request
+     * @return ExpressionDescriptor|null
+     */
+    public static function describeAutoJoinPath(
+        PathRequest $request
+    ): ?ExpressionDescriptor {
+        return match ($request->path) {
+            'label' => ExpressionDescriptor::concat(
+                ['parent.name', 'name'],
+                ' / '
+            ),
+            default => parent::describeAutoJoinPath($request),
+        };
+    }
 
     /**
      * Get the parent group.

--- a/tests/Unit/Compiler/ModelDefinedPathCompilerTest.php
+++ b/tests/Unit/Compiler/ModelDefinedPathCompilerTest.php
@@ -4,6 +4,7 @@ namespace protich\AutoJoinEloquent\Tests\Compiler;
 
 use protich\AutoJoinEloquent\Tests\AutoJoinTestCase;
 use protich\AutoJoinEloquent\Tests\Models\Agent;
+use protich\AutoJoinEloquent\Tests\Models\Group;
 
 /**
  * Test: ModelDefinedPathCompilerTest
@@ -160,6 +161,172 @@ class ModelDefinedPathCompilerTest extends AutoJoinTestCase
         $actual = Agent::query()->select('statusAlias')->toSql();
 
         $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Test every scalar aggregate descriptor compiles through relationship
+     * resolution using the function represented by its factory.
+     *
+     * @return void
+     */
+    public function test_scalar_aggregate_descriptors_compile(): void
+    {
+        $paths = [
+            'departmentIdSum' => 'SUM',
+            'departmentIdAverage' => 'AVG',
+            'departmentIdMinimum' => 'MIN',
+            'departmentIdMaximum' => 'MAX',
+        ];
+
+        foreach ($paths as $path => $function) {
+            $sql = Agent::query()
+                ->select("{$path} as aggregate_value")
+                ->toSql();
+
+            $this->assertStringContainsString("{$function}(", $sql);
+            $this->assertStringContainsString(
+                'as "aggregate_value"',
+                $sql
+            );
+        }
+    }
+
+    /**
+     * Test COALESCE descriptors resolve each relationship path in order.
+     *
+     * @return void
+     */
+    public function test_coalesce_descriptor_compiles_and_executes(): void
+    {
+        $agent = Agent::query()
+            ->where('user_id', 1)
+            ->select('preferredContact as contact')
+            ->firstOrFail();
+
+        $this->assertSame('peter@osticket.com', $agent->contact);
+        $this->assertStringContainsString(
+            'COALESCE(',
+            Agent::query()
+                ->select('preferredContact as contact')
+                ->toSql()
+        );
+    }
+
+    /**
+     * Test concatenation descriptors skip null paths and retain separators.
+     *
+     * @return void
+     */
+    public function test_concat_descriptor_compiles_and_executes(): void
+    {
+        $agent = Agent::query()
+            ->where('user_id', 1)
+            ->select('displayLabel as label')
+            ->firstOrFail();
+
+        $this->assertSame(
+            'Peter Rotich / Auto Join Package Developer',
+            $agent->label
+        );
+        $this->assertStringContainsString(
+            'CONCAT_WS(\' / \',',
+            Agent::query()
+                ->select('displayLabel as label')
+                ->toSql()
+        );
+
+        $contact = Agent::query()
+            ->where('user_id', 1)
+            ->select('contactLabel as label')
+            ->firstOrFail();
+
+        $this->assertSame('peter@osticket.com', $contact->label);
+    }
+
+    /**
+     * Test scalar composite descriptors compile in WHERE and ORDER BY.
+     *
+     * @return void
+     */
+    public function test_composite_descriptors_compile_across_clauses(): void
+    {
+        $query = Agent::query()
+            ->select('displayLabel as label')
+            ->where(
+                'preferredContact',
+                'peter@osticket.com'
+            )
+            ->orderBy('displayLabel');
+
+        $sql = $query->toSql();
+
+        $this->assertStringContainsString('COALESCE(', $sql);
+        $this->assertStringContainsString('CONCAT_WS(', $sql);
+        $this->assertStringContainsString(
+            'order by "label" asc',
+            $sql
+        );
+        $this->assertSame(
+            'Peter Rotich / Auto Join Package Developer',
+            $query->firstOrFail()->label
+        );
+    }
+
+    /**
+     * Test aggregate descriptor types obey the normal WHERE restriction.
+     *
+     * @return void
+     */
+    public function test_aggregate_descriptors_are_rejected_in_where(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage(
+            'Aggregate expressions are not allowed in WHERE clauses.'
+        );
+
+        Agent::query()->where('departmentIdSum', '>', 0)->toSql();
+    }
+
+    /**
+     * Test composite descriptors rebase through a downstream model hop.
+     *
+     * @return void
+     */
+    public function test_composite_descriptor_paths_are_rebased(): void
+    {
+        $sql = \protich\AutoJoinEloquent\Tests\Models\User::query()
+            ->select('agent__displayLabel as agent_label')
+            ->toSql();
+
+        $this->assertStringContainsString('CONCAT_WS(', $sql);
+        $this->assertStringContainsString('as "agent_label"', $sql);
+        $this->assertSame(2, substr_count($sql, 'join'));
+    }
+
+    /**
+     * Test concatenation qualifies children through a nullable self-parent.
+     *
+     * @return void
+     */
+    public function test_concat_descriptor_supports_nullable_self_parent(): void
+    {
+        $labels = Group::query()
+            ->select(['name', 'label as qualified_label'])
+            ->orderBy('label')
+            ->pluck('qualified_label', 'name');
+
+        $this->assertSame('Support', $labels['Support']);
+        $this->assertSame(
+            'Support / Escalations',
+            $labels['Escalations']
+        );
+
+        $sql = Group::query()
+            ->select('label as qualified_label')
+            ->toSql();
+
+        $this->assertStringContainsString('CONCAT_WS(', $sql);
+        $this->assertSame(1, substr_count($sql, 'join "ost_groups"'));
     }
 
     /**

--- a/tests/Unit/Model/ExpressionDescriptorTest.php
+++ b/tests/Unit/Model/ExpressionDescriptorTest.php
@@ -67,6 +67,87 @@ class ExpressionDescriptorTest extends TestCase
     }
 
     /**
+     * Ensure every scalar aggregate has a typed factory and SQL function.
+     *
+     * @return void
+     */
+    public function test_scalar_aggregate_factories_are_complete(): void
+    {
+        $descriptors = [
+            ExpressionDescriptor::sum(' departments.id ', true),
+            ExpressionDescriptor::avg('departments.id'),
+            ExpressionDescriptor::min('departments.id'),
+            ExpressionDescriptor::max('departments.id'),
+        ];
+
+        $this->assertSame(
+            [
+                ExpressionDescriptor::TYPE_SUM,
+                ExpressionDescriptor::TYPE_AVG,
+                ExpressionDescriptor::TYPE_MIN,
+                ExpressionDescriptor::TYPE_MAX,
+            ],
+            array_map(
+                static fn (ExpressionDescriptor $descriptor): string =>
+                    $descriptor->type(),
+                $descriptors
+            )
+        );
+        $this->assertSame(
+            ['SUM', 'AVG', 'MIN', 'MAX'],
+            array_map(
+                static fn (ExpressionDescriptor $descriptor): ?string =>
+                    $descriptor->aggregateFunction(),
+                $descriptors
+            )
+        );
+        $this->assertSame(['departments.id'], $descriptors[0]->paths());
+        $this->assertTrue($descriptors[0]->distinct());
+    }
+
+    /**
+     * Ensure COALESCE preserves ordered path fallback semantics.
+     *
+     * @return void
+     */
+    public function test_coalesce_preserves_ordered_paths(): void
+    {
+        $descriptor = ExpressionDescriptor::coalesce([
+            ' user.phone ',
+            'user.email',
+        ]);
+
+        $this->assertSame(
+            ExpressionDescriptor::TYPE_COALESCE,
+            $descriptor->type()
+        );
+        $this->assertSame(
+            ['user.phone', 'user.email'],
+            $descriptor->paths()
+        );
+    }
+
+    /**
+     * Ensure CONCAT preserves its path order and separator verbatim.
+     *
+     * @return void
+     */
+    public function test_concat_preserves_paths_and_separator(): void
+    {
+        $descriptor = ExpressionDescriptor::concat(
+            [' parent.name ', 'name'],
+            ' / '
+        );
+
+        $this->assertSame(
+            ExpressionDescriptor::TYPE_CONCAT,
+            $descriptor->type()
+        );
+        $this->assertSame(['parent.name', 'name'], $descriptor->paths());
+        $this->assertSame(' / ', $descriptor->separator());
+    }
+
+    /**
      * Ensure an empty path descriptor is rejected.
      *
      * @return void
@@ -127,5 +208,31 @@ class ExpressionDescriptorTest extends TestCase
             'departments.id',
             ' ',
         ]);
+    }
+
+    /**
+     * Ensure composite descriptors require at least two paths.
+     *
+     * @return void
+     */
+    public function test_coalesce_requires_two_paths(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('requires at least 2 paths');
+
+        ExpressionDescriptor::coalesce(['name']);
+    }
+
+    /**
+     * Ensure concatenation requires at least two paths.
+     *
+     * @return void
+     */
+    public function test_concat_requires_two_paths(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('requires at least 2 paths');
+
+        ExpressionDescriptor::concat(['name']);
     }
 }


### PR DESCRIPTION
Auto Joiner **v0.11.1** completes the typed `ExpressionDescriptor` API introduced in v0.11.0. Models can now describe every scalar expression family already understood by the column compiler without returning raw SQL or moving domain-specific behavior into the package.

This closes an important gap in model-owned paths. A model can expose a semantic path such as `label`, define it as a null-skipping concatenation of `parent.name` and `name`, and use that path consistently in SELECT, WHERE, and ORDER BY operations. The same mechanism now covers scalar aggregates and ordered null fallback.

Existing `path()` and `count()` descriptors remain compatible. The PHP, Illuminate, and model-hook contracts introduced in v0.11 are unchanged.

## Typed expression contract

The descriptor vocabulary now matches the scalar expression families supported by the compiler:

| Descriptor | Purpose | Clause behavior |
| --- | --- | --- |
| `path()` | Redirect to another local or relationship path | Available wherever the resolved path is valid |
| `count()` | Count one path or a distinct union of paths | Multi-path counts remain valid scalar subqueries in WHERE |
| `sum()` | Sum one resolved path | Rejected in WHERE; use HAVING for aggregate criteria |
| `avg()` | Average one resolved path | Rejected in WHERE; use HAVING for aggregate criteria |
| `min()` | Resolve the minimum value for one path | Rejected in WHERE; use HAVING for aggregate criteria |
| `max()` | Resolve the maximum value for one path | Rejected in WHERE; use HAVING for aggregate criteria |
| `coalesce()` | Return the first non-null value from ordered paths | Compiles as a scalar expression across supported clauses |
| `concat()` | Join ordered, non-null path values with a separator | Compiles with null-skipping `CONCAT_WS` semantics |

Each descriptor validates and normalizes its paths at construction. Scalar aggregates require exactly one path. `coalesce()` and `concat()` require at least two paths, preserving their order as part of the expression contract.

## Model-owned semantic paths

Models can expose hierarchy-aware labels without teaching Auto Joiner about the domain:

```php
public static function describeAutoJoinPath(
    PathRequest $request
): ?ExpressionDescriptor {
    return match ($request->path) {
        'label' => ExpressionDescriptor::concat(
            ['parent.name', 'name'],
            ' / '
        ),
        default => parent::describeAutoJoinPath($request),
    };
}
```

The semantic path can then be selected, filtered, or sorted like a physical column:

```php
Service::query()
    ->withAutoJoins()
    ->select('label as qualified_label')
    ->orderBy('label');
```

A root record with no parent resolves to `Email Services`. A child resolves to `Email Services / Inbound`. `CONCAT_WS` skips the null parent value, so the root label does not gain a leading separator.

## Relationship rebasing

Descriptor paths remain relative to the model that owns the semantic expression. When another model reaches the descriptor through a relationship, Auto Joiner rebases every path onto the relationship prefix already resolved by the query.

This applies to:

- scalar aggregate descriptors;
- ordered `coalesce()` paths;
- ordered `concat()` paths and separators;
- descriptors reconstructed while query paths are cloned or rebased.

The compiler preserves join reuse, aliases, bindings, relationship constraints, and circular descriptor protection while resolving the expanded descriptor types.

## Compiler and clause behavior

The base compiler now dispatches model-defined descriptors through the same expression implementations used by parsed column expressions. This keeps typed model paths and string-based compiler expressions behaviorally aligned.

Scalar aggregates are deliberately rejected in WHERE, matching the existing rule for direct aggregate expressions. Aggregate criteria belong in HAVING. Multi-path `count()` remains valid in WHERE because it compiles to a correlated scalar subquery rather than a direct aggregate in the outer clause.

`coalesce()` and `concat()` resolve every member path through the normal relationship pipeline. Concatenation separators are escaped through the active query grammar before SQL is emitted.

## Compatibility and release contract

This is an additive patch release:

- existing `path()` and `count()` descriptors do not require changes;
- nullable `describeAutoJoinPath()` ownership remains unchanged;
- the optional `model__` compatibility marker remains supported;
- PHP 8.3 and Illuminate Database 13 requirements remain unchanged;
- the visible package version advances to `v0.11.1` for the matching release tag.

`README.md` now presents the complete descriptor vocabulary, while `UPGRADING.md` documents the v0.11.0 to v0.11.1 behavior and clause rules.

## Test coverage

The complete package suite passes with 124 tests and 380 assertions. Focused descriptor and model-path coverage passes with 30 tests and 69 assertions.

Coverage includes:

- factories and normalization for every descriptor type;
- scalar aggregate compilation for SUM, AVG, MIN, and MAX;
- aggregate rejection in WHERE;
- COALESCE compilation, execution, and path ordering;
- CONCAT compilation, execution, separator preservation, and null skipping;
- semantic labels across nullable self-parent relationships;
- downstream descriptor rebasing through model hops;
- SELECT, WHERE, and ORDER BY composition;
- descriptor reconstruction during path rebasing;
- existing path and count behavior.

The complete PHPStan analysis and the focused maximum-level model API analysis both pass without errors. Composer metadata validation also passes.

## Review checklist

- [ ] Confirm the new factories complete the compiler-supported scalar vocabulary without exposing raw SQL.
- [ ] Verify aggregate descriptors preserve function and distinct semantics during rebasing.
- [ ] Verify `coalesce()` and `concat()` preserve ordered paths across relationship hops.
- [ ] Confirm `CONCAT_WS` provides the intended null-skipping hierarchy-label behavior.
- [ ] Confirm separator escaping is delegated to the active query grammar.
- [ ] Verify scalar aggregates are rejected in WHERE while scalar count subqueries remain valid.
- [ ] Confirm existing `path()`, `count()`, nullable ownership, and `model__` behavior remain compatible.
- [ ] Review the v0.11.1 upgrade and release documentation.
